### PR TITLE
chore(ios): update ReactNativeBiometrics to 0.6.1 and simplify key in…

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1654,7 +1654,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - ReactNativeBiometrics (0.2.0):
+  - ReactNativeBiometrics (0.6.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1975,7 +1975,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: 041559ba76d00f6680dfa0916b3c791f4babe5ea
   ReactCommon: 1511ef100f1afa4c199fe52fe7a8d2529a41429a
-  ReactNativeBiometrics: 26eaa535c2c2aacccbb62ab074c2308da06530a9
+  ReactNativeBiometrics: 8a767d7bbc3b957946ed8fecde6c0167da322026
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 50518ade05048235d91a78b803336dbb5b159d5d
 


### PR DESCRIPTION
resloves definetly: https://github.com/sbaiahmed1/react-native-biometrics/issues/7

## Summary by Sourcery

Simplify iOS key integrity validation by removing manual biometric prompts and relying on direct signature creation with built-in Secure Enclave authentication, unify CFError-to-ReactNativeBiometricsError mapping, and update the ReactNativeBiometrics dependency to version 0.6.1.

Enhancements:
- Streamline validateKeyIntegrity by directly using SecKeyCreateSignature and eliminating performBiometricAuthentication wrapper
- Map common SecKey signature errors (e.g., user cancel, auth failure) to ReactNativeBiometricsError and unify error logging and response

Build:
- Bump ReactNativeBiometrics iOS dependency to 0.6.1 in Podfile.lock