### PR TITLE
refactor(biometrics): update module to use generated spec and exclude generated files

### DIFF
--- a/ReactNativeBiometrics.podspec
+++ b/ReactNativeBiometrics.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/sbaiahmed1/sbaiahmed1-react-native-biometrics.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
+  s.exclude_files = "ios/generated/**/*"
   s.private_header_files = "ios/**/*.h"
   s.swift_version = "5.0"
   s.dependency "React-Core"

--- a/android/src/newarch/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsModule.kt
+++ b/android/src/newarch/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsModule.kt
@@ -7,15 +7,15 @@ import com.facebook.react.bridge.ReadableMap
 
 /**
  * New Architecture (TurboModule) implementation of ReactNativeBiometricsModule
- * This extends ReactNativeBiometricsSpec which implements TurboModule
+ * This extends the generated NativeReactNativeBiometricsSpec from codegen
  */
 class ReactNativeBiometricsModule(reactContext: ReactApplicationContext) :
-  ReactNativeBiometricsSpec(reactContext) {
-  
+  NativeReactNativeBiometricsSpec(reactContext) {
+
   companion object {
     const val NAME = "ReactNativeBiometrics"
   }
-  
+
   private val sharedImpl = ReactNativeBiometricsSharedImpl(reactContext)
 
   override fun getName() = NAME
@@ -35,67 +35,67 @@ class ReactNativeBiometricsModule(reactContext: ReactApplicationContext) :
   override fun authenticateWithOptions(options: ReadableMap, promise: Promise) {
     sharedImpl.authenticateWithOptions(options, promise)
   }
-  
+
   @ReactMethod
   override fun createKeys(keyAlias: String?, keyType: String?, promise: Promise) {
     sharedImpl.createKeysWithType(keyAlias, keyType, promise)
   }
-  
+
   @ReactMethod
   override fun deleteKeys(keyAlias: String?, promise: Promise) {
     sharedImpl.deleteKeys(keyAlias, promise)
   }
-  
+
   @ReactMethod
   override fun getAllKeys(customAlias: String?, promise: Promise) {
     sharedImpl.getAllKeys(customAlias, promise)
   }
-  
+
   @ReactMethod
   override fun validateKeyIntegrity(keyAlias: String?, promise: Promise) {
     sharedImpl.validateKeyIntegrity(keyAlias, promise)
   }
-  
+
   @ReactMethod
   override fun verifyKeySignature(keyAlias: String?, data: String, promptTitle: String?, promptSubtitle: String?, cancelButtonText: String?, promise: Promise) {
     sharedImpl.verifyKeySignature(keyAlias, data, promptTitle, promptSubtitle, cancelButtonText, promise)
   }
-  
+
   @ReactMethod
   override fun validateSignature(keyAlias: String?, data: String, signature: String, promise: Promise) {
     sharedImpl.validateSignature(keyAlias, data, signature, promise)
   }
-  
+
   @ReactMethod
   override fun getKeyAttributes(keyAlias: String?, promise: Promise) {
     sharedImpl.getKeyAttributes(keyAlias, promise)
   }
-  
+
   @ReactMethod
   override fun configureKeyAlias(keyAlias: String, promise: Promise) {
     sharedImpl.configureKeyAlias(keyAlias, promise)
   }
-  
+
   @ReactMethod
   override fun getDefaultKeyAlias(promise: Promise) {
     sharedImpl.getDefaultKeyAlias(promise)
   }
-  
+
   @ReactMethod
   override fun getDiagnosticInfo(promise: Promise) {
     sharedImpl.getDiagnosticInfo(promise)
   }
-  
+
   @ReactMethod
   override fun runBiometricTest(promise: Promise) {
     sharedImpl.runBiometricTest(promise)
   }
-  
+
   @ReactMethod
   override fun setDebugMode(enabled: Boolean, promise: Promise) {
     sharedImpl.setDebugMode(enabled, promise)
   }
-  
+
   @ReactMethod
   override fun getDeviceIntegrityStatus(promise: Promise) {
     sharedImpl.getDeviceIntegrityStatus(promise)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1654,7 +1654,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - ReactNativeBiometrics (0.6.2):
+  - ReactNativeBiometrics (0.7.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1975,7 +1975,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: 041559ba76d00f6680dfa0916b3c791f4babe5ea
   ReactCommon: 1511ef100f1afa4c199fe52fe7a8d2529a41429a
-  ReactNativeBiometrics: edca494d7964181ad729871c3119edb50600bfa4
+  ReactNativeBiometrics: f127f312656db9de710c755691b861d15c449c16
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 50518ade05048235d91a78b803336dbb5b159d5d
 


### PR DESCRIPTION
resolves: https://github.com/sbaiahmed1/react-native-biometrics/issues/17

- Update ReactNativeBiometricsModule to extend NativeReactNativeBiometricsSpec.
- Exclude generated files from podspec to avoid build conflicts.

## Summary by Sourcery

Refactor the new architecture Android module to use the generated TurboModule spec and update the iOS podspec to ignore generated files.

Enhancements:
- Extend ReactNativeBiometricsModule from the generated NativeReactNativeBiometricsSpec for codegen TurboModule support
- Exclude generated files from the iOS Podspec to prevent build conflicts