### PR TITLE
fix(biometrics): enhance compatibility for iOS 16+ and OpticID support

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1654,7 +1654,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - ReactNativeBiometrics (0.7.0):
+  - ReactNativeBiometrics (0.9.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1975,7 +1975,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: 041559ba76d00f6680dfa0916b3c791f4babe5ea
   ReactCommon: 1511ef100f1afa4c199fe52fe7a8d2529a41429a
-  ReactNativeBiometrics: f127f312656db9de710c755691b861d15c449c16
+  ReactNativeBiometrics: 704d2218748c6f5a89a718541346fc0726323dcf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 50518ade05048235d91a78b803336dbb5b159d5d
 

--- a/ios/Utils.swift
+++ b/ios/Utils.swift
@@ -150,8 +150,8 @@ public func createBiometricAccessControl(for keyType: BiometricKeyType = .ec256)
     // matching the old implementation default behavior (when allowDeviceCredentials == FALSE)
     return SecAccessControlCreateWithFlags(
       kCFAllocatorDefault,
-      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-      .biometryAny,
+kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+.biometryAny,
       nil
     )
   } else {
@@ -200,7 +200,7 @@ public func createKeyGenerationAttributes(
         kSecAttrAccessControl as String: accessControl
       ]
     ]
-    
+
   case .ec256:
     return [
       kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
@@ -280,7 +280,7 @@ private func checkJailbreakMethod1() -> Bool {
     "/usr/lib/libcycript.dylib",
     "/System/Library/LaunchDaemons/com.openssh.sshd.plist"
   ]
-  
+
   for path in jailbreakPaths {
     if FileManager.default.fileExists(atPath: path) {
       return true
@@ -298,7 +298,7 @@ private func checkJailbreakMethod2() -> Bool {
     "/private/jailbreak_test.txt",
     "/private/var/mobile/jailbreak_test.txt"
   ]
-  
+
   for path in testPaths {
     do {
       try testString.write(toFile: path, atomically: true, encoding: .utf8)
@@ -322,14 +322,14 @@ private func checkJailbreakMethod3() -> Bool {
       return true
     }
   }
-  
+
   // Check if we can open suspicious URLs (jailbroken devices may have custom URL schemes)
   let suspiciousURLs = [
     "cydia://package/com.example.package",
     "sileo://package/com.example.package",
     "zbra://package/com.example.package"
   ]
-  
+
   for urlString in suspiciousURLs {
     if let url = URL(string: urlString) {
       if UIApplication.shared.canOpenURL(url) {
@@ -337,7 +337,7 @@ private func checkJailbreakMethod3() -> Bool {
       }
     }
   }
-  
+
   return false
 }
 
@@ -353,7 +353,7 @@ public func isDeviceCompromised() -> Bool {
  */
 public func getDeviceIntegrityStatus() -> [String: Any] {
   let isJailbroken = isDeviceJailbroken()
-  
+
   return [
     "isJailbroken": isJailbroken,
     "isCompromised": isJailbroken,


### PR DESCRIPTION
- Replace deprecated `kSecUseAuthenticationUIFail` with LAContext for no-interaction authentication.
- Add conditional support for OpticID based on iOS 17+ availability.
- Clean up redundant whitespace for better code readability.

## Summary by Sourcery

Update biometric authentication implementation to use modern no-interaction contexts on iOS 16+, add OpticID availability checks for iOS 17+, and clean up code formatting.

New Features:
- Add conditional OpticID support on iOS 17 and above

Enhancements:
- Replace deprecated kSecUseAuthenticationUIFail with LAContext (interactionNotAllowed) on iOS 16+ to perform no-interaction keychain queries

Chores:
- Remove redundant whitespace in Swift source files