### PR TITLE
chore: add errorCode to verifyKeySignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,7 @@ Generates a cryptographic signature for the provided data using the specified ke
 - `promptTitle` (optional): Title text displayed in the signature prompt dialog.
 - `promptSubtitle` (optional): Subtitle text providing additional context in the prompt dialog (Android only).
 - `cancelButtonText` (optional): Text for the cancel button in the prompt dialog (Android only).
+- Returns a `SignatureResult` with `success`, `signature`, `error`, and `errorCode` (when available) on both iOS and Android.
 
 #### `validateSignature(data: string, signature: string, keyAlias?: string): Promise<SignatureValidationResult>`
 Validates a signature against the original data using the public key.

--- a/src/NativeReactNativeBiometrics.ts
+++ b/src/NativeReactNativeBiometrics.ts
@@ -74,6 +74,7 @@ export interface Spec extends TurboModule {
     success: boolean;
     signature?: string;
     error?: string;
+    errorCode?: string;
   }>;
   validateSignature(
     keyAlias: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -558,6 +558,7 @@ export type SignatureResult = {
   success: boolean;
   signature?: string;
   error?: string;
+  errorCode?: string;
 };
 
 export type SignatureValidationResult = {


### PR DESCRIPTION
### Summary
 - Added reusable helpers to Android’s shared implementation so every `verifyKeySignature` failure resolves with both an error message and a mapped `errorCode`, covering key lookup issues, prompt setup problems, biometric errors, and signature failures for parity with iOS.
 - Extended the JS surface so `SignatureResult` and the native TurboModule spec expose the optional errorCode, enabling apps to consume the new Android values without type errors.
 - Documented the cross-platform shape of SignatureResult so consumers know to expect errorCode from both platforms.

## Summary by Sourcery

Add errorCode to Android's verifyKeySignature native implementation, expose the new field in the JS type definitions, and document the enhanced SignatureResult shape across platforms

New Features:
- Return errorCode alongside error messages in verifyKeySignature failures on Android
- Expose optional errorCode property on SignatureResult in the JS TurboModule spec

Enhancements:
- Extract BiometricPrompt error code mapping and error result creation into reusable helper functions in the Android shared implementation

Documentation:
- Update README to include the errorCode field in the cross-platform SignatureResult documentation