### PR TITLE
fix(ios): display promptTitle when generating signature

### DIFF
--- a/ios/ReactNativeBiometrics.swift
+++ b/ios/ReactNativeBiometrics.swift
@@ -755,6 +755,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
     let secureEnclaveQuery = createKeychainQuery(
       keyTag: keyTag,
       includeSecureEnclave: true,
+      promptTitle: promptTitle,
       returnRef: true
     )
     
@@ -765,6 +766,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
       let regularQuery = createKeychainQuery(
         keyTag: keyTag,
         includeSecureEnclave: false,
+        promptTitle: promptTitle,
         returnRef: true
       )
       

--- a/ios/Utils.swift
+++ b/ios/Utils.swift
@@ -111,6 +111,7 @@ public func generateKeyAlias(customAlias: String? = nil, configuredAlias: String
 public func createKeychainQuery(
   keyTag: String,
   includeSecureEnclave: Bool = true,
+  promptTitle: NSString? = nil,
   returnRef: Bool = false,
   returnAttributes: Bool = false
 ) -> [String: Any] {
@@ -125,6 +126,12 @@ public func createKeychainQuery(
 
   if includeSecureEnclave {
     query[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
+  }
+
+  if let promptTitle = promptTitle as? String {
+    let context = LAContext()
+    context.localizedReason = promptTitle
+    query[kSecUseAuthenticationContext as String] = context
   }
 
   if returnRef {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable biometric prompt titles are now supported during key signature verification, enabling applications to display more context-specific and descriptive authentication messages to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->