### PR TITLE
fix(android): remove silent fallback to keys not requiring authentication

### DIFF
--- a/ios/ReactNativeBiometrics.swift
+++ b/ios/ReactNativeBiometrics.swift
@@ -353,7 +353,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
                   resolver resolve: @escaping RCTPromiseResolveBlock,
                   rejecter reject: @escaping RCTPromiseRejectBlock) {
     ReactNativeBiometricDebug.debugLog("createKeys called with keyAlias: \(keyAlias ?? "default"), keyType: \(keyType ?? "ec256"), biometricStrength: \(biometricStrength ?? "strong")")
-
+    
     let keyTag = getKeyAlias(keyAlias as String?)
     guard let keyTagData = keyTag.data(using: .utf8) else {
       handleError(.dataEncodingFailed, reject: reject)


### PR DESCRIPTION
Currently in case of a biometry not enrolled error during key creation, there is a silent fallback that tries creating the key again, without requiring authentication from user.
This pull request removes this fallback, as such behaviour could pose a security risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Simplified biometric authentication flow: user authentication is now always required during key generation
  * Enrollment failure handling no longer attempts fallback authentication or retries
  * Reduced diagnostic logging during biometric operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->