### PR TITLE
fix: Importing const/types on web throwing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ android {
 -keep class com.sbaiahmed1.reactnativebiometrics.** { *; }
 ```
 
+### Importing Types on Non-Native Platforms
+
+The `AuthType` and `BiometricStrength` enums can be safely imported from `@sbaiahmed1/react-native-biometrics/types` on non-mobile platforms (e.g. web), as this entry point does not load native modules.
+
+```typescript
+import { AuthType, BiometricStrength } from '@sbaiahmed1/react-native-biometrics/types';
+```
+
 ## 📖 Usage
 
 ### 🔍 Quick Start

--- a/package.json
+++ b/package.json
@@ -16,6 +16,17 @@
         "default": "./lib/commonjs/index.js"
       }
     },
+    "./types": {
+      "source": "./src/types.ts",
+      "import": {
+        "types": "./lib/typescript/module/src/types.d.ts",
+        "default": "./lib/module/types.js"
+      },
+      "require": {
+        "types": "./lib/typescript/commonjs/src/types.d.ts",
+        "default": "./lib/commonjs/types.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/src/NativeReactNativeBiometrics.ts
+++ b/src/NativeReactNativeBiometrics.ts
@@ -198,6 +198,26 @@ export interface Spec extends TurboModule {
   readonly onBiometricChange: EventEmitter<BiometricChangeEvent>;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>(
-  'ReactNativeBiometrics'
-) ?? NativeModules.ReactNativeBiometrics;
+let module: Spec | null = null;
+
+function getNativeModule(): Spec {
+  if (!module) {
+    module =
+      TurboModuleRegistry.get<Spec>('ReactNativeBiometrics') ??
+      NativeModules.ReactNativeBiometrics;
+  }
+  if (!module) {
+    throw new Error(
+      'ReactNativeBiometrics native module is not available. ' +
+        'Biometric functions are not supported on this platform.'
+    );
+  }
+  return module;
+}
+
+export default new Proxy({} as Spec, {
+  get(_target, prop) {
+    if (typeof prop === 'symbol' || prop === 'then') return undefined;
+    return getNativeModule()[prop as keyof Spec];
+  },
+});

--- a/src/NativeReactNativeBiometrics.ts
+++ b/src/NativeReactNativeBiometrics.ts
@@ -198,26 +198,6 @@ export interface Spec extends TurboModule {
   readonly onBiometricChange: EventEmitter<BiometricChangeEvent>;
 }
 
-let module: Spec | null = null;
-
-function getNativeModule(): Spec {
-  if (!module) {
-    module =
-      TurboModuleRegistry.get<Spec>('ReactNativeBiometrics') ??
-      NativeModules.ReactNativeBiometrics;
-  }
-  if (!module) {
-    throw new Error(
-      'ReactNativeBiometrics native module is not available. ' +
-        'Biometric functions are not supported on this platform.'
-    );
-  }
-  return module;
-}
-
-export default new Proxy({} as Spec, {
-  get(_target, prop) {
-    if (typeof prop === 'symbol' || prop === 'then') return undefined;
-    return getNativeModule()[prop as keyof Spec];
-  },
-});
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'ReactNativeBiometrics'
+) ?? NativeModules.ReactNativeBiometrics;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "@sbaiahmed1/react-native-biometrics": ["./src/index"]
+      "@sbaiahmed1/react-native-biometrics": ["./src/index"],
+      "@sbaiahmed1/react-native-biometrics/types": ["./src/types"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
This change adds a separate export path for types, so that importing just the types does not break on web.

Even if the library is used for mobile biometrics only, some applications want to share the type interfaces (e.g. `AuthType`) between their web and mobile implementations which was not possible until now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package now exposes a dedicated types entry so TypeScript typings and runtime entry points are available for both module systems.
* **Developer tooling**
  * Added a path alias to simplify IDE/type-resolution and importing the library's types.
* **Documentation**
  * New README section explaining how to import enums/types on non-native (non-mobile) platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->