### PR TITLE
Fix: Normalize empty keyAlias to undefined before native bridge call

### DIFF
--- a/src/NativeReactNativeBiometrics.ts
+++ b/src/NativeReactNativeBiometrics.ts
@@ -84,7 +84,7 @@ export interface Spec extends TurboModule {
     error?: string;
   }>;
   verifyKeySignature(
-    keyAlias: string,
+    keyAlias: string | null,
     data: string,
     promptTitle?: string,
     promptSubtitle?: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -269,12 +269,13 @@ export function verifyKeySignature(
   cancelButtonText?: string,
   returnAuthType?: boolean
 ): Promise<SignatureResult> {
+  const resolvedKeyAlias = keyAlias || undefined;
   logger.debug('Verifying key signature', 'verifyKeySignature', {
     keyAlias,
     dataLength: data.length,
   });
   return ReactNativeBiometrics.verifyKeySignature(
-    keyAlias,
+    resolvedKeyAlias,
     data,
     promptTitle,
     promptSubtitle,
@@ -341,6 +342,8 @@ export function signWithOptions(
     returnAuthType,
   } = options;
 
+  const resolvedKeyAlias = keyAlias || undefined;
+
   logger.debug('Signing with options', 'signWithOptions', {
     keyAlias,
     dataLength: data.length,
@@ -361,7 +364,7 @@ export function signWithOptions(
   // On Android, use the new method with options
   if (Platform.OS === 'android') {
     return ReactNativeBiometrics.verifyKeySignatureWithOptions(
-      keyAlias,
+      resolvedKeyAlias,
       data,
       promptTitle,
       promptSubtitle,
@@ -388,7 +391,7 @@ export function signWithOptions(
 
   // On iOS, use the standard method with inputEncoding
   return ReactNativeBiometrics.verifyKeySignatureWithEncoding(
-    keyAlias,
+    resolvedKeyAlias,
     data,
     promptTitle,
     promptSubtitle,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -269,7 +269,7 @@ export function verifyKeySignature(
   cancelButtonText?: string,
   returnAuthType?: boolean
 ): Promise<SignatureResult> {
-  const resolvedKeyAlias = keyAlias || undefined;
+  const resolvedKeyAlias = keyAlias || null;
   logger.debug('Verifying key signature', 'verifyKeySignature', {
     keyAlias,
     dataLength: data.length,
@@ -342,7 +342,7 @@ export function signWithOptions(
     returnAuthType,
   } = options;
 
-  const resolvedKeyAlias = keyAlias || undefined;
+  const resolvedKeyAlias = keyAlias || null;
 
   logger.debug('Signing with options', 'signWithOptions', {
     keyAlias,


### PR DESCRIPTION
## Problem

`signWithOptions` and `verifyKeySignature` default `keyAlias` to an empty string `''` when none is provided. This empty string gets passed as-is to the Android native layer.

In `ReactNativeBiometricsSharedImpl.kt`, `getKeyAlias` only falls back to the default alias (`"biometric_key"`) when receiving `null` — an empty string is not `null` in Kotlin, so no fallback occurs:

```kotlin
private fun getKeyAlias(keyAlias: String? = null): String {
    return keyAlias ?: configuredKeyAlias ?: run { ... }
}
```

As a result, the native layer looks for a key with alias `""` in the Android Keystore, finds nothing, and returns `{ success: false, error: "Key not found" }` — without ever showing the biometric prompt.

## Fix

Normalize `keyAlias` to `null` before passing it to the native bridge, so the existing Kotlin fallback works correctly:

```ts
const resolvedKeyAlias = keyAlias || null;
```

Applied to both `signWithOptions` and `verifyKeySignature`. The native type definition for `verifyKeySignature` in `NativeReactNativeBiometrics.ts` is updated from `string` to `string | null` to match the Kotlin implementation (which already accepts `String?`) and be consistent with `verifyKeySignatureWithOptions` and `verifyKeySignatureWithEncoding`. No changes to public API signatures or defaults.

## Behaviour after fix

Calling `signWithOptions({ data, promptTitle })` or `verifyKeySignature('', data)` without a `keyAlias` now behaves identically to passing `keyAlias: 'biometric_key'` — the biometric prompt is shown and the default key is used.