### PR TITLE
fix: recover from late keystore auth token delivery when signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,6 +1471,7 @@ Common error codes returned by authentication methods:
 | `BIOMETRY_NOT_AVAILABLE` | Biometry not available | iOS |
 | `BIOMETRY_NOT_ENROLLED` | No biometrics enrolled | iOS |
 | `BIOMETRY_LOCKOUT` | Too many failed attempts | Both |
+| `KEY_USER_NOT_AUTHENTICATED` | Keystore rejected the signing operation despite successful authentication (OEM auth-token delivery bug; automatically retried before this is returned — prompt the user to try again) | Android |
 
 
 ## 📱 Example App

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
@@ -1287,16 +1287,20 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
         override fun onAuthenticationSucceeded(authResult: BiometricPrompt.AuthenticationResult) {
           debugLog("verifyKeySignature - Authentication succeeded, generating signature")
 
-          // If cryptoObject carries the signature, the user authenticated via biometrics
-          // (hardware-atomic binding — highest security).
-          // If null, the user chose device credential: Android does not bind CryptoObject
-          // to device credential auth, but the Keystore key is still unlocked
-          // via the fresh auth token, so we can call sign() on the pre-initialized signature.
-          val usedDeviceCredential = authResult.cryptoObject?.signature == null
-          val authenticatedSignature = authResult.cryptoObject?.signature ?: signature
+          // Prefer the signature bound to the authentication result. On API 30+ the
+          // CryptoObject is returned even for device-credential authentication; a null
+          // signature only means the platform did not bind the CryptoObject, in which
+          // case the pre-initialized signature is the best remaining option.
+          val cryptoSignature = authResult.cryptoObject?.signature
+          val authenticatedSignature = cryptoSignature ?: signature
 
-          if (usedDeviceCredential) {
-            debugLog("verifyKeySignature - Device credential used, signing with pre-initialized signature")
+          // CryptoObject presence does not indicate how the user authenticated —
+          // classify device-credential usage from the reported authentication type.
+          val usedDeviceCredential = authResult.authenticationType ==
+            BiometricPrompt.AUTHENTICATION_RESULT_TYPE_DEVICE_CREDENTIAL
+
+          if (cryptoSignature == null) {
+            debugLog("verifyKeySignature - CryptoObject not bound to result, signing with pre-initialized signature")
           }
 
           fun resolveSuccess(signatureBytes: ByteArray) {

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
@@ -39,6 +39,15 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
     const val DEFAULT_KEY_ALIAS = "biometric_key"
     const val PREFS_NAME = "ReactNativeBiometricsPrefs"
     const val KEY_ALIAS_PREF = "keyAlias"
+
+    // On some OEM builds (observed on Motorola and Xiaomi devices) the Keystore auth token
+    // produced by a successful BiometricPrompt authentication is delivered asynchronously and
+    // may not have reached Keystore when onAuthenticationSucceeded fires, so an immediate
+    // sign() aborts the CryptoObject-bound operation with KEY_USER_NOT_AUTHENTICATED (-26)
+    // even though the user genuinely authenticated.
+    // See https://issuetracker.google.com/issues/129937212
+    const val AUTH_TOKEN_PROPAGATION_DELAY_MS = 150L
+    const val SIGN_RETRY_DELAY_MS = 250L
   }
 
   // Data class for biometric state tracking
@@ -107,6 +116,13 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
     errorResult.putString("errorCode", code)
     errorResult.putInt("authType", 0)
     return errorResult
+  }
+
+  private fun isUserNotAuthenticatedError(error: Throwable): Boolean {
+    return generateSequence(error) { it.cause }.any {
+      it is android.security.keystore.UserNotAuthenticatedException ||
+        it.message?.contains("user not authenticated", ignoreCase = true) == true
+    }
   }
 
   private fun mapBiometricPromptErrorCode(errorCode: Int): String {
@@ -1271,21 +1287,19 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
         override fun onAuthenticationSucceeded(authResult: BiometricPrompt.AuthenticationResult) {
           debugLog("verifyKeySignature - Authentication succeeded, generating signature")
 
-          try {
-            // If cryptoObject carries the signature, the user authenticated via biometrics
-            // (hardware-atomic binding — highest security).
-            // If null, the user chose device credential: Android does not bind CryptoObject
-            // to device credential auth, but the Keystore key is still unlocked
-            // via the fresh auth token, so we can call sign() on the pre-initialized signature.
-            val usedDeviceCredential = authResult.cryptoObject?.signature == null
-            val authenticatedSignature = authResult.cryptoObject?.signature ?: signature
+          // If cryptoObject carries the signature, the user authenticated via biometrics
+          // (hardware-atomic binding — highest security).
+          // If null, the user chose device credential: Android does not bind CryptoObject
+          // to device credential auth, but the Keystore key is still unlocked
+          // via the fresh auth token, so we can call sign() on the pre-initialized signature.
+          val usedDeviceCredential = authResult.cryptoObject?.signature == null
+          val authenticatedSignature = authResult.cryptoObject?.signature ?: signature
 
-            if (usedDeviceCredential) {
-              debugLog("verifyKeySignature - Device credential used, signing with pre-initialized signature")
-            }
+          if (usedDeviceCredential) {
+            debugLog("verifyKeySignature - Device credential used, signing with pre-initialized signature")
+          }
 
-            authenticatedSignature.update(dataBytes)
-            val signatureBytes = authenticatedSignature.sign()
+          fun resolveSuccess(signatureBytes: ByteArray) {
             val signatureString = BiometricUtils.encodeBase64(signatureBytes)
 
             val result = Arguments.createMap()
@@ -1304,12 +1318,45 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
 
             debugLog("verifyKeySignature completed successfully (deviceCredential=$usedDeviceCredential)")
             promise.resolve(result)
-
-          } catch (e: Exception) {
-            debugLog("verifyKeySignature - Signature generation failed: ${e.message}")
-            val message = "Failed to generate signature: ${e.message ?: "Unknown error"}"
-            promise.resolve(createSignatureErrorResult(message, "SIGNATURE_CREATION_FAILED"))
           }
+
+          val mainHandler = Handler(Looper.getMainLooper())
+
+          // Delay the first sign() slightly so a late-delivered auth token can reach Keystore
+          // before the CryptoObject-bound operation is finished (see companion constants).
+          // The delay is hidden by the prompt dismissal animation.
+          mainHandler.postDelayed({
+            try {
+              authenticatedSignature.update(dataBytes)
+              resolveSuccess(authenticatedSignature.sign())
+            } catch (e: Exception) {
+              if (!isUserNotAuthenticatedError(e)) {
+                debugLog("verifyKeySignature - Signature generation failed: ${e.message}")
+                val message = "Failed to generate signature: ${e.message ?: "Unknown error"}"
+                promise.resolve(createSignatureErrorResult(message, "SIGNATURE_CREATION_FAILED"))
+                return@postDelayed
+              }
+
+              // A failed sign() aborts the bound Keystore operation, so it cannot be reused.
+              // Retry once on a freshly initialized Signature after another short delay — by
+              // then the auth token is registered, and Keystore implementations that validate
+              // by recent authentication (rather than strict per-operation challenge) accept it.
+              debugLog("verifyKeySignature - KEY_USER_NOT_AUTHENTICATED after successful auth, retrying with fresh signature")
+              mainHandler.postDelayed({
+                try {
+                  val retrySignature = Signature.getInstance(BiometricUtils.getSignatureAlgorithm(privateKey))
+                  retrySignature.initSign(privateKey)
+                  retrySignature.update(dataBytes)
+                  resolveSuccess(retrySignature.sign())
+                } catch (retryError: Exception) {
+                  debugLog("verifyKeySignature - Retry after KEY_USER_NOT_AUTHENTICATED failed: ${retryError.message}")
+                  val code = if (isUserNotAuthenticatedError(retryError)) "KEY_USER_NOT_AUTHENTICATED" else "SIGNATURE_CREATION_FAILED"
+                  val message = "Failed to generate signature: ${retryError.message ?: "Unknown error"}"
+                  promise.resolve(createSignatureErrorResult(message, code))
+                }
+              }, SIGN_RETRY_DELAY_MS)
+            }
+          }, AUTH_TOKEN_PROPAGATION_DELAY_MS)
         }
 
         override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {


### PR DESCRIPTION
## Summary

Fixes the `KEY_USER_NOT_AUTHENTICATED` (Keystore -26) failure in `signWithOptions` / `verifyKeySignature` reported in #91, where signing fails **after a successful biometric authentication** on certain OEM devices (reported on Motorola Edge 50 Neo / Moto G23 / Edge 40 Neo and Xiaomi 14 / 14 Ultra / Redmi Note 14 Pro+, Android 14–16).

## Root cause

AOSP registers the Keystore auth token **before** invoking `onAuthenticationSucceeded`, but some OEM-customized biometric services deliver the token asynchronously. When the callback fires first, the immediate `sign()` fails with `KEY_USER_NOT_AUTHENTICATED` even though the user genuinely authenticated (see [google/issuetracker#129937212](https://issuetracker.google.com/issues/129937212)). Worse, a failed `sign()` aborts the `CryptoObject`-bound Keystore operation, so the failure was previously unrecoverable.

## Changes

- Delay the first `sign()` attempt by 150 ms so a late-delivered auth token can reach Keystore while the CryptoObject-bound operation (and its challenge) is still alive. The delay is hidden by the prompt dismissal animation.
- If the operation was already aborted with `KEY_USER_NOT_AUTHENTICATED`, retry once on a freshly initialized `Signature` after another 250 ms — this recovers on Keystore implementations that validate by recent authentication rather than strict per-operation challenge.
- Surface a distinct `KEY_USER_NOT_AUTHENTICATED` error code (previously buried in the generic `SIGNATURE_CREATION_FAILED`) so apps can show a targeted retry prompt; documented in the README error-code table.

No changes to key generation or to the CryptoObject binding itself — the security model is unchanged.

## Testing

- `:sbaiahmed1_react-native-biometrics:compileDebugKotlin` passes (new arch codegen included).
- Existing Jest suite passes (85/85).
- **Regression-verified end to end on the Android emulator** (Pixel, API 35, fingerprint enrolled): `createKeys('ec256')` (auth-bound key) → `Generate Signature` → BiometricPrompt → fingerprint auth → signature produced, and `validateSignature` returned `valid: true` against the public key. Debug logcat shows the fix executing as designed:

  ```
  22:39:43.814  verifyKeySignature - Authentication succeeded, generating signature
  22:39:43.972  verifyKeySignature completed successfully (deviceCredential=false)
  ```

  158 ms apart — the 150 ms token-propagation delay plus the sign itself; the first attempt succeeds and the retry branch stays dormant on a compliant device, i.e. no behavior change on healthy hardware.
- The `KEY_USER_NOT_AUTHENTICATED` failure itself is OEM-device-specific and does not reproduce on emulators; verification on affected hardware (Motorola/Xiaomi) is requested from the reporter in #91.

Refs #91
