### PR TITLE
fix: deliver biometric change events on the new architecture and iOS

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -35,5 +35,15 @@ target 'ReactNativeBiometricsExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Xcode 26's Apple clang rejects fmt 11's consteval FMT_STRING usages
+    # (https://github.com/fmtlib/fmt/issues/4740). Building the fmt pod as
+    # C++17 makes fmt's own version check disable consteval.
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'fmt'
+      target.build_configurations.each do |config|
+        config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+      end
+    end
   end
 end

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1063,3 +1063,41 @@ describe('ReactNativeBiometrics', () => {
     });
   });
 });
+
+describe('Biometric Change Events', () => {
+  const NativeBiometrics: any = jest.requireMock(
+    '../NativeReactNativeBiometrics'
+  );
+
+  afterEach(() => {
+    delete NativeBiometrics.onBiometricChange;
+  });
+
+  it('should subscribe via the TurboModule event emitter when available (new architecture)', () => {
+    const mockSubscription = { remove: jest.fn() };
+    NativeBiometrics.onBiometricChange = jest.fn(() => mockSubscription);
+
+    const callback = jest.fn();
+    const subscription = Biometrics.subscribeToBiometricChanges(callback);
+
+    expect(NativeBiometrics.onBiometricChange).toHaveBeenCalledWith(callback);
+    expect(subscription).toBe(mockSubscription);
+  });
+
+  it('should fall back to an event emitter subscription without the TurboModule emitter (old architecture)', () => {
+    const subscription = Biometrics.subscribeToBiometricChanges(jest.fn());
+
+    expect(typeof subscription.remove).toBe('function');
+    subscription.remove();
+  });
+
+  it('should remove the subscription when unsubscribing', () => {
+    const mockSubscription = { remove: jest.fn() };
+    NativeBiometrics.onBiometricChange = jest.fn(() => mockSubscription);
+
+    const subscription = Biometrics.subscribeToBiometricChanges(jest.fn());
+    Biometrics.unsubscribeFromBiometricChanges(subscription);
+
+    expect(mockSubscription.remove).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1068,9 +1068,16 @@ describe('Biometric Change Events', () => {
   const NativeBiometrics: any = jest.requireMock(
     '../NativeReactNativeBiometrics'
   );
+  // Earlier tests in this file call jest.resetModules(), and react-native's
+  // exports are lazy getters resolved against the current module registry —
+  // react-native must therefore be required inside each test so the spies
+  // attach to the same instances the library resolves at call time.
+  const reactNative = () => require('react-native');
 
   afterEach(() => {
     delete NativeBiometrics.onBiometricChange;
+    delete reactNative().NativeModules.ReactNativeBiometrics;
+    jest.restoreAllMocks();
   });
 
   it('should subscribe via the TurboModule event emitter when available (new architecture)', () => {
@@ -1084,10 +1091,45 @@ describe('Biometric Change Events', () => {
     expect(subscription).toBe(mockSubscription);
   });
 
-  it('should fall back to an event emitter subscription without the TurboModule emitter (old architecture)', () => {
-    const subscription = Biometrics.subscribeToBiometricChanges(jest.fn());
+  it('should subscribe via NativeEventEmitter when the native module exists (old architecture)', () => {
+    const { NativeEventEmitter, NativeModules } = reactNative();
+    NativeModules.ReactNativeBiometrics = {
+      addListener: jest.fn(),
+      removeListeners: jest.fn(),
+    };
+    const nativeEmitterAddListener = jest.spyOn(
+      NativeEventEmitter.prototype,
+      'addListener'
+    );
 
-    expect(typeof subscription.remove).toBe('function');
+    const callback = jest.fn();
+    const subscription = Biometrics.subscribeToBiometricChanges(callback);
+
+    expect(nativeEmitterAddListener).toHaveBeenCalledWith(
+      'onBiometricChange',
+      callback
+    );
+    // The native addListener call is what un-gates iOS RCTEventEmitter emission.
+    expect(
+      NativeModules.ReactNativeBiometrics.addListener
+    ).toHaveBeenCalledWith('onBiometricChange');
+    subscription.remove();
+  });
+
+  it('should fall back to DeviceEventEmitter without the native module', () => {
+    const { DeviceEventEmitter } = reactNative();
+    const deviceEmitterAddListener = jest.spyOn(
+      DeviceEventEmitter,
+      'addListener'
+    );
+
+    const callback = jest.fn();
+    const subscription = Biometrics.subscribeToBiometricChanges(callback);
+
+    expect(deviceEmitterAddListener).toHaveBeenCalledWith(
+      'onBiometricChange',
+      callback
+    );
     subscription.remove();
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,8 @@ import { type LogEntry, logger, LogLevel } from './logger';
 import {
   DeviceEventEmitter,
   type EventSubscription,
+  NativeEventEmitter,
+  NativeModules,
   Platform,
 } from 'react-native';
 import { AuthType, BiometricStrength } from './types';
@@ -895,8 +897,23 @@ export function subscribeToBiometricChanges(
     'subscribeToBiometricChanges'
   );
 
-  // Subscribe using DeviceEventEmitter for cross-architecture compatibility
-  // The native modules emit events via DeviceEventManagerModule
+  // New architecture: events emitted through the codegen event emitter are
+  // only delivered to its own subscribers, never to DeviceEventEmitter.
+  if (typeof ReactNativeBiometrics.onBiometricChange === 'function') {
+    return ReactNativeBiometrics.onBiometricChange(callback);
+  }
+
+  // Old architecture: NativeEventEmitter invokes the native addListener
+  // method — required on iOS, where RCTEventEmitter drops events while its
+  // listener count is zero — and both platforms auto-start detection when
+  // the first listener attaches.
+  if (NativeModules.ReactNativeBiometrics != null) {
+    return new NativeEventEmitter(
+      NativeModules.ReactNativeBiometrics
+    ).addListener('onBiometricChange', callback);
+  }
+
+  // Environments without the native module (e.g. web).
   return DeviceEventEmitter.addListener('onBiometricChange', callback);
 }
 


### PR DESCRIPTION
## Summary

Fixes #53 — biometric change events never reached the `subscribeToBiometricChanges` listener with the new architecture enabled. Investigation showed the breakage was wider than reported: iOS dropped events on **both** architectures.

## Root cause

`subscribeToBiometricChanges` listened only via `DeviceEventEmitter`, which fails in two independent ways:

- **New architecture (Android):** events emitted through the codegen `emitOnBiometricChange` are only delivered to subscribers of the TurboModule's `onBiometricChange` event emitter — never to `DeviceEventEmitter` listeners.
- **iOS (both architectures):** `RCTEventEmitter` drops every event while its native listener count is zero (`shouldEmitEvent = (_observationDisabled || _listenerCount > 0)`), and only the native `addListener` method increments that count — which `DeviceEventEmitter.addListener` never calls. This also meant the `startObserving()` auto-start documented in `BIOMETRIC_CHANGE_DETECTION.md` never ran.

## Changes

`subscribeToBiometricChanges` now routes by what is actually available:

1. **Codegen event emitter** (`ReactNativeBiometrics.onBiometricChange`) when the TurboModule exposes it — the new-architecture path.
2. **`NativeEventEmitter`** otherwise — invokes the native `addListener`, which un-gates iOS emission, triggers `startObserving()` on iOS, and auto-starts detection on Android old arch.
3. **`DeviceEventEmitter`** as a last resort for environments without the native module (web, tests).

`unsubscribeFromBiometricChanges` is unchanged — both subscription types expose `remove()`.

## Testing

- 3 new Jest tests covering the routing (TurboModule emitter preferred, fallback path, unsubscribe); 85/85 pass; `tsc` and ESLint clean.
- **Verified end-to-end on the Android emulator with the new architecture enabled** (Pixel emulator, API 35, `newArchEnabled=true`, runtime confirmed `RN$Bridgeless === true` and Fabric active): tapping *Start Detection* in the example app immediately delivered a `STATE_CHANGED` event to the JS listener, and enrolling a fingerprint in Settings then returning to the app delivered `ENROLLMENT_CHANGED` — alert shown and status card updated:

  | Step | Result |
  |---|---|
  | Start detection (baseline: no fingerprint) | `STATE_CHANGED` received, listener active |
  | Enroll fingerprint in Settings, resume app | `ENROLLMENT_CHANGED` alert + `Enrolled: Yes` in status card |

- **Verified end-to-end on the iOS simulator with the new architecture** (iPhone 17 Pro, `RCT_NEW_ARCH_ENABLED=1`, runtime confirmed `RN$Bridgeless === true`) — the path that was completely dead before this fix:

  | Step | Result |
  |---|---|
  | Start detection (baseline: Face ID not enrolled) | Listener active, status `Available: No, Enrolled: No` |
  | Background app, enroll Face ID (simulator toggle), relaunch | `BIOMETRIC_ENABLED` alert + `Enrolled: Yes / Type: FaceID` in status card |

> Note: this PR also includes a small example-only commit building the `fmt` pod as C++17 so the example iOS app compiles under Xcode 26 (fmt 11 consteval incompatibility, [fmtlib/fmt#4740](https://github.com/fmtlib/fmt/issues/4740)); removable once React Native ships fmt >= 12.

Fixes #53
