### PR TITLE
feat: hardware-backed non-biometric RSA/EC signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - 📱 **Multiple Biometric Types** - Face ID, Touch ID, Fingerprint, and more
 - 🛠️ **Advanced Options** - Customizable prompts, fallback options, and device credentials
 - 🔑 **Key Management** - Create and manage cryptographic keys (EC256/RSA2048) for secure operations
+- 🔏 **Non-Biometric Signing** - Hardware-backed RSA/EC signing without prompts (SHA-256/SHA-512) — a modern `react-native-rsa-native` alternative
 - 🛡️ **Device Integrity** - Detect compromised devices (rooted/jailbroken) for enhanced security
 - 🔔 **Biometric Change Detection** - Real-time monitoring of biometric enrollment changes with event-driven updates ([docs](./BIOMETRIC_CHANGE_DETECTION.md))
 - 🐛 **Debug Tools** - Comprehensive diagnostic and testing utilities
@@ -586,6 +587,53 @@ const keyLifecycleExample = async () => {
 };
 ```
 
+### 🔏 Non-Biometric Signing (Hardware-Backed, No Prompts)
+
+Create Keychain/Keystore-backed RSA or EC keys that sign **without any biometric prompt** — the modern replacement for the `react-native-rsa-native` use case. The private key never leaves the secure hardware; only the user-authentication requirement is removed.
+
+```typescript
+import {
+  createKeysWithOptions,
+  keyExists,
+  getPublicKey,
+  sign,
+  deleteKeys,
+  SignatureAlgorithm,
+} from '@sbaiahmed1/react-native-biometrics';
+
+const deviceBoundSigningExample = async () => {
+  // Create a hardware-backed RSA-2048 key that never prompts
+  await createKeysWithOptions({
+    keyAlias: 'server-auth-key',
+    keyType: 'rsa2048',
+    requireAuthentication: false,
+  });
+
+  // Prompt-free existence check
+  if (await keyExists('server-auth-key')) {
+    // Public key as base64 X.509 SubjectPublicKeyInfo DER on both platforms —
+    // consumable directly by e.g. `openssl pkey -pubin -inform DER`
+    const { publicKey } = await getPublicKey('server-auth-key');
+    await sendPublicKeyToServer(publicKey);
+  }
+
+  // Sign a payload — no prompt appears
+  const result = await sign({
+    keyAlias: 'server-auth-key',
+    data: 'payload-to-sign',
+    algorithm: SignatureAlgorithm.SHA512withRSA, // optional, defaults to SHA-256
+  });
+
+  if (result.success) {
+    console.log('✍️ Signature:', result.signature);
+  }
+};
+```
+
+`sign()` never prompts: called on a normal biometric-gated key it resolves with `{ success: false, errorCode: 'KEY_REQUIRES_AUTHENTICATION' }` — use `signWithOptions()` for those. Conversely, `signWithOptions()` on a no-auth key signs silently with `authType: 0`.
+
+> 📖 **See the [Cryptographic Keys Guide](./docs/CRYPTOGRAPHIC_KEYS.md) for algorithm constraints (SHA-512 availability on Android/StrongBox), key accessibility, and public key format details.**
+
 ### 🐛 Debugging Utilities
 
 Comprehensive debugging tools to help troubleshoot biometric authentication issues.
@@ -868,6 +916,91 @@ console.log('Keys created:', result.publicKey);
 const rsaKeys = await createKeys(undefined, 'rsa2048');
 const ecKeys = await createKeys(undefined, 'ec256');
 ```
+```
+
+#### `createKeysWithOptions(options?)`
+
+Options-object variant of `createKeys` with one additional capability: `requireAuthentication: false` creates a hardware-backed key that can sign **without any biometric prompt** (see [`sign()`](#signoptions)).
+
+```typescript
+const createKeysWithOptions = (options?: {
+  keyAlias?: string;
+  keyType?: 'ec256' | 'rsa2048';
+  requireAuthentication?: boolean;   // default true (same behavior as createKeys)
+  biometricStrength?: BiometricStrength;   // ignored when requireAuthentication is false
+  allowDeviceCredentials?: boolean;        // ignored when requireAuthentication is false
+  failIfExists?: boolean;
+}): Promise<KeyResult> => {
+};
+```
+
+With `requireAuthentication: false`:
+- The private key remains non-exportable in the Android Keystore / iOS Keychain (Secure Enclave for EC keys on device), but using it never requires user authentication.
+- No biometric enrollment or passcode is required at creation time on either platform (iOS uses `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, so the key is only usable while the device is unlocked).
+
+**Example:**
+```javascript
+const result = await createKeysWithOptions({
+  keyAlias: 'server-auth-key',
+  keyType: 'rsa2048',
+  requireAuthentication: false,
+});
+```
+
+#### `keyExists(keyAlias?)`
+
+Checks whether a key exists for the alias without triggering any biometric prompt.
+
+```typescript
+const keyExists = (keyAlias?: string): Promise<boolean> => {
+};
+```
+
+#### `getPublicKey(keyAlias?)`
+
+Retrieves the public key without triggering any biometric prompt. Unlike the `publicKey` returned by `createKeys`, the result is base64-encoded **X.509 SubjectPublicKeyInfo DER on both platforms and for both key types**, so it can be consumed directly by standard tooling (`openssl pkey -pubin -inform DER`). Rejects with `KEY_NOT_FOUND` if no key exists.
+
+```typescript
+const getPublicKey = (keyAlias?: string): Promise<{
+  publicKey: string;   // Base64 X.509 SPKI DER
+  keyType?: string;    // 'rsa2048' | 'ec256'
+}> => {
+};
+```
+
+#### `sign(options)`
+
+Signs data **without any user authentication prompt**. Only works with keys created via `createKeysWithOptions({ requireAuthentication: false })`; on a biometric-gated key it never prompts — it resolves with `{ success: false, errorCode: 'KEY_REQUIRES_AUTHENTICATION' }` (use `signWithOptions()` for those keys).
+
+```typescript
+const sign = (options: {
+  keyAlias?: string;
+  data: string;
+  inputEncoding?: InputEncoding;      // 'utf8' (default) | 'base64'
+  algorithm?: SignatureAlgorithm;     // defaults to the SHA-256 variant for the key type
+}): Promise<SignatureResult> => {
+};
+
+enum SignatureAlgorithm {
+  SHA256withRSA = 'SHA256withRSA',
+  SHA512withRSA = 'SHA512withRSA',
+  SHA256withECDSA = 'SHA256withECDSA',
+  SHA512withECDSA = 'SHA512withECDSA',
+}
+```
+
+**Error codes:** `KEY_NOT_FOUND`, `KEY_REQUIRES_AUTHENTICATION`, `INVALID_ALGORITHM` (algorithm/key-type mismatch), `UNSUPPORTED_ALGORITHM` (e.g. SHA-512 on an Android key minted before SHA-512 support or inside StrongBox), `INVALID_INPUT_ENCODING`.
+
+**Example:**
+```javascript
+const result = await sign({
+  keyAlias: 'server-auth-key',
+  data: payload,
+  algorithm: SignatureAlgorithm.SHA512withRSA,
+});
+if (result.success) {
+  console.log('Signature:', result.signature);
+}
 ```
 
 #### `deleteKeys(keyAlias?: string)`
@@ -1715,6 +1848,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) 
 - [x] **Duplicate Key Protection**: `failIfExists` parameter for `createKeys` to prevent accidental key overwrites
 - [x] **Device Security Check**: `isDeviceSecure` field in `isSensorAvailable` result
 - [x] **iOS Simulator Support**: Full biometric prompt support on iOS Simulator via LAContext workarounds
+- [x] **Non-Biometric Signing**: Hardware-backed, prompt-free RSA/EC signing (`createKeysWithOptions`, `keyExists`, `getPublicKey`, `sign`) with SHA-256/SHA-512 — a modern `react-native-rsa-native` alternative (#90)
 
 ### 🔄 In Progress
 - [ ] **Performance Optimization**: Optimize biometric operations and reduce latency

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - 📱 **Multiple Biometric Types** - Face ID, Touch ID, Fingerprint, and more
 - 🛠️ **Advanced Options** - Customizable prompts, fallback options, and device credentials
 - 🔑 **Key Management** - Create and manage cryptographic keys (EC256/RSA2048) for secure operations
-- 🔏 **Non-Biometric Signing** - Hardware-backed RSA/EC signing without prompts (SHA-256/SHA-512) — a modern `react-native-rsa-native` alternative
+- 🔏 **Non-Biometric Signing** - Keystore/Keychain-backed RSA/EC signing without prompts (SHA-256/SHA-512), hardware-backed where supported — a modern `react-native-rsa-native` alternative
 - 🛡️ **Device Integrity** - Detect compromised devices (rooted/jailbroken) for enhanced security
 - 🔔 **Biometric Change Detection** - Real-time monitoring of biometric enrollment changes with event-driven updates ([docs](./BIOMETRIC_CHANGE_DETECTION.md))
 - 🐛 **Debug Tools** - Comprehensive diagnostic and testing utilities
@@ -587,9 +587,9 @@ const keyLifecycleExample = async () => {
 };
 ```
 
-### 🔏 Non-Biometric Signing (Hardware-Backed, No Prompts)
+### 🔏 Non-Biometric Signing (No Prompts)
 
-Create Keychain/Keystore-backed RSA or EC keys that sign **without any biometric prompt** — the modern replacement for the `react-native-rsa-native` use case. The private key never leaves the secure hardware; only the user-authentication requirement is removed.
+Create Keychain/Keystore-backed RSA or EC keys that sign **without any biometric prompt** — the modern replacement for the `react-native-rsa-native` use case. The private key never leaves the Keychain/Keystore and is hardware-backed where the platform supports it (Android TEE/StrongBox for both key types, iOS Secure Enclave for EC keys; iOS RSA keys reside in the regular Keychain); only the user-authentication requirement is removed.
 
 ```typescript
 import {
@@ -920,7 +920,7 @@ const ecKeys = await createKeys(undefined, 'ec256');
 
 #### `createKeysWithOptions(options?)`
 
-Options-object variant of `createKeys` with one additional capability: `requireAuthentication: false` creates a hardware-backed key that can sign **without any biometric prompt** (see [`sign()`](#signoptions)).
+Options-object variant of `createKeys` with one additional capability: `requireAuthentication: false` creates a Keystore/Keychain-backed key that can sign **without any biometric prompt** (see [`sign()`](#signoptions)).
 
 ```typescript
 const createKeysWithOptions = (options?: {
@@ -935,7 +935,7 @@ const createKeysWithOptions = (options?: {
 ```
 
 With `requireAuthentication: false`:
-- The private key remains non-exportable in the Android Keystore / iOS Keychain (Secure Enclave for EC keys on device), but using it never requires user authentication.
+- The private key remains non-exportable in the Android Keystore / iOS Keychain, but using it never requires user authentication. Non-exportability is guaranteed on all paths; hardware residency depends on platform and key type — Android keys are TEE/StrongBox-backed, iOS EC keys use the Secure Enclave on device, while iOS RSA keys live in the regular Keychain without hardware protection.
 - No biometric enrollment or passcode is required at creation time on either platform (iOS uses `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, so the key is only usable while the device is unlocked).
 
 **Example:**
@@ -958,7 +958,7 @@ const keyExists = (keyAlias?: string): Promise<boolean> => {
 
 #### `getPublicKey(keyAlias?)`
 
-Retrieves the public key without triggering any biometric prompt. Unlike the `publicKey` returned by `createKeys`, the result is base64-encoded **X.509 SubjectPublicKeyInfo DER on both platforms and for both key types**, so it can be consumed directly by standard tooling (`openssl pkey -pubin -inform DER`). Rejects with `KEY_NOT_FOUND` if no key exists.
+Retrieves the public key without triggering any biometric prompt. Unlike the `publicKey` returned by `createKeys`, the result is base64-encoded **X.509 SubjectPublicKeyInfo DER on both platforms and for both key types**, so it can be consumed directly by standard tooling (`openssl pkey -pubin -inform DER`). Rejects with `KEY_NOT_FOUND` if no key exists. On iOS, a biometric-gated key may reject with `KEY_REQUIRES_AUTHENTICATION` — the Keychain can refuse even a non-interactive lookup of an auth-bound key — so for those keys capture the `publicKey` returned by `createKeys` at creation time instead (Android is unaffected).
 
 ```typescript
 const getPublicKey = (keyAlias?: string): Promise<{
@@ -1848,7 +1848,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) 
 - [x] **Duplicate Key Protection**: `failIfExists` parameter for `createKeys` to prevent accidental key overwrites
 - [x] **Device Security Check**: `isDeviceSecure` field in `isSensorAvailable` result
 - [x] **iOS Simulator Support**: Full biometric prompt support on iOS Simulator via LAContext workarounds
-- [x] **Non-Biometric Signing**: Hardware-backed, prompt-free RSA/EC signing (`createKeysWithOptions`, `keyExists`, `getPublicKey`, `sign`) with SHA-256/SHA-512 — a modern `react-native-rsa-native` alternative (#90)
+- [x] **Non-Biometric Signing**: Keystore/Keychain-backed, prompt-free RSA/EC signing (`createKeysWithOptions`, `keyExists`, `getPublicKey`, `sign`) with SHA-256/SHA-512, hardware-backed where supported — a modern `react-native-rsa-native` alternative (#90)
 
 ### 🔄 In Progress
 - [ ] **Performance Optimization**: Optimize biometric operations and reduce latency

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
@@ -331,12 +331,26 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
   }
 
   fun createKeysWithType(keyAlias: String?, keyType: String?, biometricStrength: String?, allowDeviceCredentials: Boolean, failIfExists: Boolean, promise: Promise) {
+    createKeysInternal(keyAlias, keyType, biometricStrength, allowDeviceCredentials, failIfExists, requireAuthentication = true, promise = promise)
+  }
+
+  fun createKeysWithOptions(options: ReadableMap, promise: Promise) {
+    val keyAlias = if (options.hasKey("keyAlias")) options.getString("keyAlias") else null
+    val keyType = if (options.hasKey("keyType")) options.getString("keyType") else null
+    val requireAuthentication = if (options.hasKey("requireAuthentication")) options.getBoolean("requireAuthentication") else true
+    val biometricStrength = if (options.hasKey("biometricStrength")) options.getString("biometricStrength") else null
+    val allowDeviceCredentials = if (options.hasKey("allowDeviceCredentials")) options.getBoolean("allowDeviceCredentials") else false
+    val failIfExists = if (options.hasKey("failIfExists")) options.getBoolean("failIfExists") else false
+    createKeysInternal(keyAlias, keyType, biometricStrength, allowDeviceCredentials, failIfExists, requireAuthentication, promise)
+  }
+
+  private fun createKeysInternal(keyAlias: String?, keyType: String?, biometricStrength: String?, allowDeviceCredentials: Boolean, failIfExists: Boolean, requireAuthentication: Boolean, promise: Promise) {
     val actualKeyAlias = getKeyAlias(keyAlias)
     val actualKeyType = keyType?.lowercase() ?: "rsa2048"
     val requestedStrength = biometricStrength ?: "strong"
-    debugLog("createKeys called with keyAlias: ${keyAlias ?: "default"}, using: $actualKeyAlias, keyType: $actualKeyType, biometricStrength: $requestedStrength, allowDeviceCredentials: $allowDeviceCredentials")
+    debugLog("createKeys called with keyAlias: ${keyAlias ?: "default"}, using: $actualKeyAlias, keyType: $actualKeyType, biometricStrength: $requestedStrength, allowDeviceCredentials: $allowDeviceCredentials, requireAuthentication: $requireAuthentication")
 
-    if (allowDeviceCredentials && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
+    if (requireAuthentication && allowDeviceCredentials && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
       debugLog("createKeys failed - allowDeviceCredentials requires Android API 30+")
       promise.reject("CREATE_KEYS_ERROR", "allowDeviceCredentials requires Android API 30+", null)
       return
@@ -369,19 +383,29 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
               actualKeyAlias,
               KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY
             )
-              .setDigests(KeyProperties.DIGEST_SHA256)
               .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
               .setKeySize(2048)
 
-            builder.setUserAuthenticationRequired(true)
-            if (allowDeviceCredentials) {
-              builder.setUserAuthenticationParameters(
-                0, // require auth for every use
-                KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
-              )
-
+            // StrongBox is only mandated to support SHA-256; listing SHA-512 there
+            // could fail generation and silently demote the key to TEE via the
+            // fallback below.
+            if (strongBox) {
+              builder.setDigests(KeyProperties.DIGEST_SHA256)
             } else {
-              builder.setUserAuthenticationValidityDurationSeconds(-1) // Biometric only
+              builder.setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+            }
+
+            if (requireAuthentication) {
+              builder.setUserAuthenticationRequired(true)
+              if (allowDeviceCredentials) {
+                builder.setUserAuthenticationParameters(
+                  0, // require auth for every use
+                  KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+                )
+
+              } else {
+                builder.setUserAuthenticationValidityDurationSeconds(-1) // Biometric only
+              }
             }
 
             if (strongBox) {
@@ -449,18 +473,28 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
               actualKeyAlias,
               KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY
             )
-              .setDigests(KeyProperties.DIGEST_SHA256)
               .setKeySize(256)
 
-            builder.setUserAuthenticationRequired(true)
-            if (allowDeviceCredentials) {
-              builder.setUserAuthenticationParameters(
-                0, // require auth for every use
-                KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
-              )
-
+            // StrongBox is only mandated to support SHA-256; listing SHA-512 there
+            // could fail generation and silently demote the key to TEE via the
+            // fallback below.
+            if (strongBox) {
+              builder.setDigests(KeyProperties.DIGEST_SHA256)
             } else {
-              builder.setUserAuthenticationValidityDurationSeconds(-1) // Biometric only
+              builder.setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+            }
+
+            if (requireAuthentication) {
+              builder.setUserAuthenticationRequired(true)
+              if (allowDeviceCredentials) {
+                builder.setUserAuthenticationParameters(
+                  0, // require auth for every use
+                  KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+                )
+
+              } else {
+                builder.setUserAuthenticationValidityDurationSeconds(-1) // Biometric only
+              }
             }
 
             if (strongBox) {
@@ -594,6 +628,41 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
     } catch (e: Exception) {
       debugLog("deleteKeys failed - Unexpected error: ${e.message}")
       promise.reject("DELETE_KEYS_ERROR", "Failed to delete keys: ${e.message}", e)
+    }
+  }
+
+  fun getPublicKey(keyAlias: String?, promise: Promise) {
+    val actualKeyAlias = getKeyAlias(keyAlias)
+    debugLog("getPublicKey called with keyAlias: ${keyAlias ?: "default"}, using: $actualKeyAlias")
+    try {
+      val keyStore = KeyStore.getInstance("AndroidKeyStore")
+      keyStore.load(null)
+
+      if (!keyStore.containsAlias(actualKeyAlias)) {
+        debugLog("getPublicKey failed - No key found with alias '$actualKeyAlias'")
+        promise.reject("KEY_NOT_FOUND", "No key found with alias '$actualKeyAlias'", null)
+        return
+      }
+
+      val publicKey = keyStore.getCertificate(actualKeyAlias)?.publicKey
+      if (publicKey == null) {
+        debugLog("getPublicKey failed - No certificate for alias '$actualKeyAlias'")
+        promise.reject("KEY_NOT_FOUND", "No public key found for alias '$actualKeyAlias'", null)
+        return
+      }
+
+      val result = Arguments.createMap()
+      // PublicKey.encoded is X.509 SubjectPublicKeyInfo DER
+      result.putString("publicKey", BiometricUtils.encodeBase64(publicKey.encoded))
+      when (publicKey) {
+        is java.security.interfaces.RSAKey -> result.putString("keyType", "rsa2048")
+        is java.security.interfaces.ECKey -> result.putString("keyType", "ec256")
+      }
+      debugLog("getPublicKey completed for alias '$actualKeyAlias'")
+      promise.resolve(result)
+    } catch (e: Exception) {
+      debugLog("getPublicKey failed - Unexpected error: ${e.message}")
+      promise.reject("GET_PUBLIC_KEY_ERROR", "Failed to get public key: ${e.message}", e)
     }
   }
 
@@ -1144,6 +1213,95 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
         }
       }
       else -> data.toByteArray(Charsets.UTF_8)
+    }
+  }
+
+  /**
+   * Signs data without any user authentication prompt. Only works with keys
+   * created with requireAuthentication = false; auth-bound keys resolve with
+   * KEY_REQUIRES_AUTHENTICATION instead of prompting.
+   */
+  fun signData(options: ReadableMap, promise: Promise) {
+    val keyAlias = if (options.hasKey("keyAlias")) options.getString("keyAlias") else null
+    val data = if (options.hasKey("data")) options.getString("data") else null
+    val inputEncoding = (if (options.hasKey("inputEncoding")) options.getString("inputEncoding") else null) ?: "utf8"
+    val requestedAlgorithm = if (options.hasKey("algorithm")) options.getString("algorithm") else null
+    val actualKeyAlias = getKeyAlias(keyAlias)
+    debugLog("signData called with keyAlias: ${keyAlias ?: "default"}, using: $actualKeyAlias, inputEncoding: $inputEncoding, algorithm: ${requestedAlgorithm ?: "default"}")
+
+    if (data == null) {
+      promise.resolve(createSignatureErrorResult("No data provided", "INVALID_INPUT"))
+      return
+    }
+
+    val dataBytes = decodeInputData(data, inputEncoding)
+    if (dataBytes == null) {
+      promise.resolve(createSignatureErrorResult("Invalid base64 data", "INVALID_INPUT_ENCODING"))
+      return
+    }
+
+    try {
+      val keyStore = KeyStore.getInstance("AndroidKeyStore")
+      keyStore.load(null)
+
+      if (!keyStore.containsAlias(actualKeyAlias)) {
+        promise.resolve(createSignatureErrorResult("Key not found", "KEY_NOT_FOUND"))
+        return
+      }
+
+      val keyEntry = keyStore.getEntry(actualKeyAlias, null)
+      if (keyEntry !is KeyStore.PrivateKeyEntry) {
+        promise.resolve(createSignatureErrorResult("Invalid key type", "INVALID_KEY_TYPE"))
+        return
+      }
+
+      val privateKey = keyEntry.privateKey
+
+      val requiresAuth = try {
+        val keyFactory = java.security.KeyFactory.getInstance(privateKey.algorithm, "AndroidKeyStore")
+        val keyInfo = keyFactory.getKeySpec(privateKey, android.security.keystore.KeyInfo::class.java)
+        keyInfo.isUserAuthenticationRequired
+      } catch (e: Exception) {
+        false
+      }
+
+      if (requiresAuth) {
+        debugLog("signData failed - Key requires user authentication")
+        promise.resolve(createSignatureErrorResult("Key requires user authentication. Use signWithOptions() instead.", "KEY_REQUIRES_AUTHENTICATION"))
+        return
+      }
+
+      val algorithm = try {
+        BiometricUtils.resolveSignatureAlgorithm(privateKey, requestedAlgorithm)
+      } catch (e: IllegalArgumentException) {
+        debugLog("signData failed - ${e.message}")
+        promise.resolve(createSignatureErrorResult(e.message ?: "Invalid algorithm", "INVALID_ALGORITHM"))
+        return
+      }
+
+      try {
+        val signature = Signature.getInstance(algorithm)
+        signature.initSign(privateKey)
+        signature.update(dataBytes)
+        val signatureBytes = signature.sign()
+
+        val result = Arguments.createMap()
+        result.putBoolean("success", true)
+        result.putString("signature", BiometricUtils.encodeBase64(signatureBytes))
+        debugLog("signData completed with $algorithm")
+        promise.resolve(result)
+      } catch (e: java.security.InvalidKeyException) {
+        // Keystore rejects digests the key was not minted with (pre-SHA512 or
+        // StrongBox keys) at initSign time.
+        debugLog("signData failed - Key does not support $algorithm: ${e.message}")
+        promise.resolve(createSignatureErrorResult("Key does not support $algorithm: ${e.message}", "UNSUPPORTED_ALGORITHM"))
+      } catch (e: Exception) {
+        debugLog("signData failed - Signing failed: ${e.message}")
+        promise.resolve(createSignatureErrorResult("Signing failed: ${e.message ?: "Unknown error"}", "SIGNATURE_CREATION_FAILED"))
+      }
+    } catch (e: Exception) {
+      debugLog("signData failed - Unexpected error: ${e.message}")
+      promise.resolve(createSignatureErrorResult("Signing failed: ${e.message ?: "Unknown error"}", "SIGNATURE_CREATION_FAILED"))
     }
   }
 

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
@@ -350,6 +350,12 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
     val requestedStrength = biometricStrength ?: "strong"
     debugLog("createKeys called with keyAlias: ${keyAlias ?: "default"}, using: $actualKeyAlias, keyType: $actualKeyType, biometricStrength: $requestedStrength, allowDeviceCredentials: $allowDeviceCredentials, requireAuthentication: $requireAuthentication")
 
+    if (biometricStrength != null && biometricStrength.lowercase() !in setOf("weak", "strong")) {
+      debugLog("createKeys failed - Invalid biometricStrength: $biometricStrength")
+      promise.reject("CREATE_KEYS_ERROR", "Invalid biometricStrength: $biometricStrength. Supported values: weak, strong", null)
+      return
+    }
+
     if (requireAuthentication && allowDeviceCredentials && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
       debugLog("createKeys failed - allowDeviceCredentials requires Android API 30+")
       promise.reject("CREATE_KEYS_ERROR", "allowDeviceCredentials requires Android API 30+", null)

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/Utils.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/Utils.kt
@@ -434,6 +434,36 @@ object BiometricUtils {
         }
     }
 
+    private val RSA_SIGNATURE_ALGORITHMS = setOf("SHA256withRSA", "SHA512withRSA")
+    private val EC_SIGNATURE_ALGORITHMS = setOf("SHA256withECDSA", "SHA512withECDSA")
+
+    /**
+     * Resolves the signature algorithm for a key, honoring an optional caller
+     * request. Falls back to the SHA-256 default for the key type when no
+     * algorithm is requested.
+     * @throws IllegalArgumentException when the requested algorithm is unknown
+     * or does not match the key type
+     */
+    fun resolveSignatureAlgorithm(key: java.security.Key, requested: String?): String {
+        if (requested == null) {
+            return getSignatureAlgorithm(key)
+        }
+        if (requested !in RSA_SIGNATURE_ALGORITHMS && requested !in EC_SIGNATURE_ALGORITHMS) {
+            throw IllegalArgumentException(
+                "Unsupported algorithm: $requested. Supported: ${(RSA_SIGNATURE_ALGORITHMS + EC_SIGNATURE_ALGORITHMS).joinToString(", ")}"
+            )
+        }
+        val matchesKeyType = when (key) {
+            is RSAKey -> requested in RSA_SIGNATURE_ALGORITHMS
+            is ECKey -> requested in EC_SIGNATURE_ALGORITHMS
+            else -> requested in RSA_SIGNATURE_ALGORITHMS
+        }
+        if (!matchesKeyType) {
+            throw IllegalArgumentException("Algorithm $requested does not match the key type (${key.algorithm})")
+        }
+        return requested
+    }
+
     /**
      * Checks if the device is rooted
      * This performs multiple checks to detect root access

--- a/android/src/newarch/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsModule.kt
+++ b/android/src/newarch/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsModule.kt
@@ -73,6 +73,21 @@ class ReactNativeBiometricsModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  override fun createKeysWithOptions(options: ReadableMap, promise: Promise) {
+    sharedImpl.createKeysWithOptions(options, promise)
+  }
+
+  @ReactMethod
+  override fun getPublicKey(keyAlias: String?, promise: Promise) {
+    sharedImpl.getPublicKey(keyAlias, promise)
+  }
+
+  @ReactMethod
+  override fun signData(options: ReadableMap, promise: Promise) {
+    sharedImpl.signData(options, promise)
+  }
+
+  @ReactMethod
   override fun deleteKeys(keyAlias: String?, promise: Promise) {
     sharedImpl.deleteKeys(keyAlias, promise)
   }

--- a/android/src/oldarch/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsModule.kt
+++ b/android/src/oldarch/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsModule.kt
@@ -47,6 +47,21 @@ class ReactNativeBiometricsModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  fun createKeysWithOptions(options: ReadableMap, promise: Promise) {
+    sharedImpl.createKeysWithOptions(options, promise)
+  }
+
+  @ReactMethod
+  fun getPublicKey(keyAlias: String?, promise: Promise) {
+    sharedImpl.getPublicKey(keyAlias, promise)
+  }
+
+  @ReactMethod
+  fun signData(options: ReadableMap, promise: Promise) {
+    sharedImpl.signData(options, promise)
+  }
+
+  @ReactMethod
   fun deleteKeys(keyAlias: String?, promise: Promise) {
     sharedImpl.deleteKeys(keyAlias, promise)
   }

--- a/docs/CRYPTOGRAPHIC_KEYS.md
+++ b/docs/CRYPTOGRAPHIC_KEYS.md
@@ -126,13 +126,17 @@ async function migrateToEC256() {
 }
 ```
 
-## Non-Biometric Signing (Hardware-Backed Keys Without Prompts)
+## Non-Biometric Signing (Keystore/Keychain Keys Without Prompts)
 
 For device-bound signing without any user interaction — server authentication,
 request signing, attestation — keys can be created with no user-authentication
 requirement. The private key still never leaves the Android Keystore / iOS
-Keychain (Secure Enclave for EC keys on device); only the prompt is removed.
-This covers the use cases previously served by `react-native-rsa-native`.
+Keychain; only the prompt is removed. Hardware backing follows the same
+platform matrix as biometric keys (see the table above): Android keys are
+TEE/StrongBox-backed, iOS EC keys use the Secure Enclave on device, and iOS
+RSA keys reside in the regular Keychain without hardware protection —
+non-exportable via the API, but not hardware-resident. This covers the use
+cases previously served by `react-native-rsa-native`.
 
 ```javascript
 import {

--- a/docs/CRYPTOGRAPHIC_KEYS.md
+++ b/docs/CRYPTOGRAPHIC_KEYS.md
@@ -126,6 +126,83 @@ async function migrateToEC256() {
 }
 ```
 
+## Non-Biometric Signing (Hardware-Backed Keys Without Prompts)
+
+For device-bound signing without any user interaction — server authentication,
+request signing, attestation — keys can be created with no user-authentication
+requirement. The private key still never leaves the Android Keystore / iOS
+Keychain (Secure Enclave for EC keys on device); only the prompt is removed.
+This covers the use cases previously served by `react-native-rsa-native`.
+
+```javascript
+import {
+  createKeysWithOptions,
+  keyExists,
+  getPublicKey,
+  sign,
+  deleteKeys,
+  SignatureAlgorithm,
+} from '@sbaiahmed1/react-native-biometrics';
+
+// 1. Create a hardware-backed key that never prompts
+const { publicKey } = await createKeysWithOptions({
+  keyAlias: 'server-auth-key',
+  keyType: 'rsa2048',
+  requireAuthentication: false,
+});
+
+// 2. Prompt-free existence check
+const exists = await keyExists('server-auth-key');
+
+// 3. Public key as base64 X.509 SubjectPublicKeyInfo DER (both platforms)
+const { publicKey: spki } = await getPublicKey('server-auth-key');
+
+// 4. Sign without any prompt
+const result = await sign({
+  keyAlias: 'server-auth-key',
+  data: payload,
+  algorithm: SignatureAlgorithm.SHA512withRSA, // optional, defaults to SHA-256
+});
+
+// 5. Cleanup
+await deleteKeys('server-auth-key');
+```
+
+### Behavior Notes
+
+- `createKeysWithOptions` defaults to `requireAuthentication: true`, which is
+  identical to `createKeys` — the non-biometric mode is strictly opt-in.
+- `sign()` never shows a prompt. Called on a biometric-gated key it resolves
+  with `{ success: false, errorCode: 'KEY_REQUIRES_AUTHENTICATION' }` — use
+  `signWithOptions()` for those keys.
+- The reverse works: `signWithOptions()` on a no-auth key signs silently and
+  resolves with `authType: 0`.
+- On iOS, no-auth keys use `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`:
+  they don't depend on a passcode being set, but are unusable while the
+  device is locked and never migrate to another device.
+
+### Signature Algorithms
+
+`sign()` accepts `SHA256withRSA`, `SHA512withRSA`, `SHA256withECDSA`, and
+`SHA512withECDSA` (the algorithm must match the key type). Constraints:
+
+- **Android**: keys created before SHA-512 support was added, and keys
+  generated inside **StrongBox**, only permit SHA-256. Requesting SHA-512 on
+  such a key fails with `UNSUPPORTED_ALGORITHM`; recreate the key to enable
+  SHA-512 (StrongBox keys stay SHA-256 only).
+- **iOS**: the algorithm is chosen per call, so SHA-512 works with existing
+  keys too.
+
+### Public Key Formats
+
+`getPublicKey()` always returns base64-encoded X.509 SubjectPublicKeyInfo
+(SPKI) DER, directly consumable by standard tooling
+(`openssl pkey -pubin -inform DER`). Note that the `publicKey` returned by
+`createKeys`/`createKeysWithOptions`/`getAllKeys` is unchanged for backward
+compatibility: on Android and for iOS EC keys it is also SPKI, but **iOS RSA
+keys are returned as raw PKCS#1 DER** there. Prefer `getPublicKey()` when a
+server needs to consume the key.
+
 ## Performance Considerations
 
 ### Key Generation Speed

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import DebuggingExample from './DebuggingExample';
 import AuthExample from './AuthExample';
 import ColorDemo from './ColorExample';
 import CombinedBiometricsDemo from './CombinedBiometricsDemo';
+import NonBiometricSigningExample from './NonBiometricSigningExample';
 import BiometricChangeExample from '../BiometricChangeExample';
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
         <AuthExample />
         <ColorDemo />
         <CombinedBiometricsDemo />
+        <NonBiometricSigningExample />
         <DebuggingExample />
       </ScrollView>
     </SafeAreaView>

--- a/example/src/NonBiometricSigningExample.tsx
+++ b/example/src/NonBiometricSigningExample.tsx
@@ -1,0 +1,343 @@
+import { View, Text, StyleSheet, Alert, TouchableOpacity } from 'react-native';
+import {
+  createKeys,
+  createKeysWithOptions,
+  keyExists,
+  getPublicKey,
+  sign,
+  deleteKeys,
+  validateSignature,
+  SignatureAlgorithm,
+} from '@sbaiahmed1/react-native-biometrics';
+import { useState } from 'react';
+
+const NO_AUTH_KEY_ALIAS = 'example-noauth-signing-key';
+const BIOMETRIC_KEY_ALIAS = 'example-biometric-key';
+const TEST_PAYLOAD = 'payload signed without a biometric prompt';
+
+const NonBiometricSigningExample = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [keyPresent, setKeyPresent] = useState<boolean | null>(null);
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [lastSignature, setLastSignature] = useState<string | null>(null);
+
+  const handleCreateNoAuthKey = async () => {
+    setIsLoading(true);
+    try {
+      const result = await createKeysWithOptions({
+        keyAlias: NO_AUTH_KEY_ALIAS,
+        keyType: 'rsa2048',
+        requireAuthentication: false,
+      });
+      console.log('No-auth key created:', result);
+      setKeyPresent(true);
+      Alert.alert(
+        'Key Created',
+        'RSA-2048 key created without authentication requirement — no prompt appeared and none will appear when signing.'
+      );
+    } catch (error) {
+      console.log('No-auth key creation error:', error);
+      Alert.alert('Error', `Key creation failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyExists = async () => {
+    setIsLoading(true);
+    try {
+      const exists = await keyExists(NO_AUTH_KEY_ALIAS);
+      console.log('keyExists:', exists);
+      setKeyPresent(exists);
+      Alert.alert('Key Exists', exists ? 'Yes' : 'No');
+    } catch (error) {
+      console.log('keyExists error:', error);
+      Alert.alert('Error', `Existence check failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleGetPublicKey = async () => {
+    setIsLoading(true);
+    try {
+      const result = await getPublicKey(NO_AUTH_KEY_ALIAS);
+      console.log('getPublicKey:', result);
+      setPublicKey(result.publicKey);
+      Alert.alert(
+        'Public Key (SPKI DER)',
+        `Type: ${result.keyType}\n${result.publicKey.substring(0, 80)}…`
+      );
+    } catch (error) {
+      console.log('getPublicKey error:', error);
+      Alert.alert('Error', `Public key retrieval failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSign = async (algorithm?: SignatureAlgorithm) => {
+    setIsLoading(true);
+    try {
+      const result = await sign({
+        keyAlias: NO_AUTH_KEY_ALIAS,
+        data: TEST_PAYLOAD,
+        algorithm,
+      });
+      console.log('sign result:', result);
+      if (result.success && result.signature) {
+        setLastSignature(result.signature);
+        Alert.alert(
+          'Signed Without Prompt',
+          `Algorithm: ${algorithm ?? 'default (SHA-256)'}\nSignature: ${result.signature.substring(0, 60)}…`
+        );
+      } else {
+        Alert.alert(
+          'Signing Failed',
+          `${result.error || 'Unknown error'} (${result.errorCode || 'no code'})`
+        );
+      }
+    } catch (error) {
+      console.log('sign error:', error);
+      Alert.alert('Error', `Signing failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleValidateSignature = async () => {
+    if (!lastSignature) {
+      Alert.alert('Error', 'Sign something first');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      // validateSignature verifies with SHA-256; use it after a default sign()
+      const result = await validateSignature(
+        NO_AUTH_KEY_ALIAS,
+        TEST_PAYLOAD,
+        lastSignature
+      );
+      console.log('validateSignature:', result);
+      Alert.alert('Validation', result.valid ? 'Signature valid' : 'INVALID');
+    } catch (error) {
+      console.log('validateSignature error:', error);
+      Alert.alert('Error', `Validation failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSignWithBiometricKey = async () => {
+    setIsLoading(true);
+    try {
+      // Create a normal biometric-gated key, then show that the prompt-free
+      // sign() refuses it with KEY_REQUIRES_AUTHENTICATION instead of prompting.
+      await createKeys(BIOMETRIC_KEY_ALIAS);
+      const result = await sign({
+        keyAlias: BIOMETRIC_KEY_ALIAS,
+        data: TEST_PAYLOAD,
+      });
+      console.log('sign on biometric key:', result);
+      Alert.alert(
+        'Expected Failure',
+        `success: ${result.success}\nerrorCode: ${result.errorCode}\n(${result.error})`
+      );
+    } catch (error) {
+      console.log('biometric key negative test error:', error);
+      Alert.alert('Error', `Negative test failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDeleteKeys = async () => {
+    setIsLoading(true);
+    try {
+      await deleteKeys(NO_AUTH_KEY_ALIAS);
+      await deleteKeys(BIOMETRIC_KEY_ALIAS);
+      setKeyPresent(false);
+      setPublicKey(null);
+      setLastSignature(null);
+      Alert.alert('Deleted', 'Example keys removed');
+    } catch (error) {
+      console.log('deleteKeys error:', error);
+      Alert.alert('Error', `Deletion failed: ${error}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>
+          Non-Biometric Signing (RSA Keychain/Keystore)
+        </Text>
+        <Text style={styles.info}>
+          Hardware-backed keys usable without any biometric prompt.
+        </Text>
+        {keyPresent !== null && (
+          <Text style={styles.info}>
+            Key exists: {keyPresent ? 'Yes' : 'No'}
+          </Text>
+        )}
+        {publicKey && (
+          <Text style={styles.publicKey} numberOfLines={3}>
+            {publicKey}
+          </Text>
+        )}
+
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            style={[styles.button, isLoading && styles.buttonDisabled]}
+            onPress={handleCreateNoAuthKey}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>Create No-Auth RSA Key</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.button, isLoading && styles.buttonDisabled]}
+            onPress={handleKeyExists}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>Check Key Exists</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.button, isLoading && styles.buttonDisabled]}
+            onPress={handleGetPublicKey}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>Get Public Key (SPKI)</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.signButton,
+              isLoading && styles.buttonDisabled,
+            ]}
+            onPress={() => handleSign()}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>Sign (SHA256withRSA)</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.signButton,
+              isLoading && styles.buttonDisabled,
+            ]}
+            onPress={() => handleSign(SignatureAlgorithm.SHA512withRSA)}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>Sign (SHA512withRSA)</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.button, isLoading && styles.buttonDisabled]}
+            onPress={handleValidateSignature}
+            disabled={isLoading || !lastSignature}
+          >
+            <Text style={styles.buttonText}>Validate Last Signature</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.negativeButton,
+              isLoading && styles.buttonDisabled,
+            ]}
+            onPress={handleSignWithBiometricKey}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>
+              sign() on Biometric Key (expected failure)
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[
+              styles.button,
+              styles.deleteButton,
+              isLoading && styles.buttonDisabled,
+            ]}
+            onPress={handleDeleteKeys}
+            disabled={isLoading}
+          >
+            <Text style={styles.buttonText}>Delete Example Keys</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default NonBiometricSigningExample;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  section: {
+    backgroundColor: 'white',
+    padding: 15,
+    marginBottom: 15,
+    marginHorizontal: 20,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 10,
+    color: '#333',
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    padding: 15,
+    borderRadius: 8,
+    marginBottom: 10,
+    alignItems: 'center',
+  },
+  signButton: {
+    backgroundColor: '#34C759',
+  },
+  negativeButton: {
+    backgroundColor: '#FF9500',
+  },
+  deleteButton: {
+    backgroundColor: '#FF3B30',
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  info: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 5,
+  },
+  buttonContainer: {
+    marginTop: 20,
+  },
+  publicKey: {
+    fontFamily: 'monospace',
+    fontSize: 12,
+    backgroundColor: '#f0f0f0',
+    padding: 10,
+    borderRadius: 4,
+  },
+});

--- a/example/src/NonBiometricSigningExample.tsx
+++ b/example/src/NonBiometricSigningExample.tsx
@@ -20,6 +20,8 @@ const NonBiometricSigningExample = () => {
   const [keyPresent, setKeyPresent] = useState<boolean | null>(null);
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [lastSignature, setLastSignature] = useState<string | null>(null);
+  const [lastSignatureAlgorithm, setLastSignatureAlgorithm] =
+    useState<SignatureAlgorithm | null>(null);
 
   const handleCreateNoAuthKey = async () => {
     setIsLoading(true);
@@ -77,19 +79,21 @@ const NonBiometricSigningExample = () => {
   };
 
   const handleSign = async (algorithm?: SignatureAlgorithm) => {
+    const selectedAlgorithm = algorithm ?? SignatureAlgorithm.SHA256withRSA;
     setIsLoading(true);
     try {
       const result = await sign({
         keyAlias: NO_AUTH_KEY_ALIAS,
         data: TEST_PAYLOAD,
-        algorithm,
+        algorithm: selectedAlgorithm,
       });
       console.log('sign result:', result);
       if (result.success && result.signature) {
         setLastSignature(result.signature);
+        setLastSignatureAlgorithm(selectedAlgorithm);
         Alert.alert(
           'Signed Without Prompt',
-          `Algorithm: ${algorithm ?? 'default (SHA-256)'}\nSignature: ${result.signature.substring(0, 60)}…`
+          `Algorithm: ${selectedAlgorithm}\nSignature: ${result.signature.substring(0, 60)}…`
         );
       } else {
         Alert.alert(
@@ -110,9 +114,16 @@ const NonBiometricSigningExample = () => {
       Alert.alert('Error', 'Sign something first');
       return;
     }
+    // validateSignature verifies with SHA-256 only
+    if (lastSignatureAlgorithm !== SignatureAlgorithm.SHA256withRSA) {
+      Alert.alert(
+        'Unsupported',
+        `validateSignature only verifies SHA-256 signatures; the last signature used ${lastSignatureAlgorithm}. Verify SHA-512 signatures server-side (e.g. openssl dgst -sha512 -verify).`
+      );
+      return;
+    }
     setIsLoading(true);
     try {
-      // validateSignature verifies with SHA-256; use it after a default sign()
       const result = await validateSignature(
         NO_AUTH_KEY_ALIAS,
         TEST_PAYLOAD,
@@ -159,6 +170,7 @@ const NonBiometricSigningExample = () => {
       setKeyPresent(false);
       setPublicKey(null);
       setLastSignature(null);
+      setLastSignatureAlgorithm(null);
       Alert.alert('Deleted', 'Example keys removed');
     } catch (error) {
       console.log('deleteKeys error:', error);
@@ -175,7 +187,7 @@ const NonBiometricSigningExample = () => {
           Non-Biometric Signing (RSA Keychain/Keystore)
         </Text>
         <Text style={styles.info}>
-          Hardware-backed keys usable without any biometric prompt.
+          Keystore/Keychain-backed keys usable without any biometric prompt.
         </Text>
         {keyPresent !== null && (
           <Text style={styles.info}>

--- a/ios/ReactNativeBiometrics.swift
+++ b/ios/ReactNativeBiometrics.swift
@@ -474,16 +474,26 @@ class ReactNativeBiometrics: RCTEventEmitter {
     
     // Parse key type
     let biometricKeyType: BiometricKeyType
-    if let keyTypeString = keyType, keyTypeString.lowercased() == "rsa2048" {
-      biometricKeyType = .rsa2048
-    } else {
+    switch keyType?.lowercased() {
+    case nil, "ec256":
       biometricKeyType = .ec256
+    case "rsa2048":
+      biometricKeyType = .rsa2048
+    default:
+      ReactNativeBiometricDebug.debugLog("createKeys failed - Unsupported key type: \(keyType ?? "")")
+      handleError(.invalidParameters, reject: reject)
+      return
     }
 
     // iOS migration-safe behavior:
     // - default/weak -> .biometryAny (backward-compatible with existing keys)
     // - strong       -> .biometryCurrentSet (invalidated on biometric enrollment change)
     let biometricStrengthValue = biometricStrength?.lowercased()
+    guard biometricStrengthValue == nil || biometricStrengthValue == "weak" || biometricStrengthValue == "strong" else {
+      ReactNativeBiometricDebug.debugLog("createKeys failed - Invalid biometricStrength: \(biometricStrength ?? "")")
+      handleError(.invalidParameters, reject: reject)
+      return
+    }
     let useBiometryCurrentSet = biometricStrengthValue == "strong"
     
     // Check if key already exists when failIfExists is true
@@ -1481,10 +1491,27 @@ class ReactNativeBiometrics: RCTEventEmitter {
     let keySize = keyAttributes[kSecAttrKeySizeInBits as String] as? Int ?? 0
     let keyType = keyAttributes[kSecAttrKeyType as String] as? String ?? "Unknown"
     let isHardwareBacked = keyAttributes[kSecAttrTokenID as String] != nil
-    
+
     // Default key purposes for biometric keys (sign and verify)
     let keyPurposes = ["sign", "verify"]
-    
+
+    // A key without an access control (no-auth RSA / simulator keys) never
+    // requires user authentication. A key with one usually does — except the
+    // no-auth Secure Enclave ACL, which carries only .privateKeyUsage.
+    let accessControlValue =
+      keyItem[kSecAttrAccessControl as String] ?? keyAttributes[kSecAttrAccessControl as String]
+    var userAuthenticationRequired = accessControlValue != nil
+    if let accessControlValue = accessControlValue,
+       let noAuthReference = SecAccessControlCreateWithFlags(
+         kCFAllocatorDefault,
+         kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+         [.privateKeyUsage],
+         nil
+       ),
+       CFEqual(accessControlValue as! SecAccessControl, noAuthReference) {
+      userAuthenticationRequired = false
+    }
+
     let attributes: [String: Any] = [
       "algorithm": keyType == kSecAttrKeyTypeRSA as String ? "RSA" : "EC",
       "keySize": keySize,
@@ -1493,7 +1520,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
       "padding": ["PKCS1"],
       "securityLevel": isHardwareBacked ? "Hardware" : "Software",
       "hardwareBacked": isHardwareBacked,
-      "userAuthenticationRequired": true
+      "userAuthenticationRequired": userAuthenticationRequired
     ]
     
     ReactNativeBiometricDebug.debugLog("getKeyAttributes completed successfully")

--- a/ios/ReactNativeBiometrics.swift
+++ b/ios/ReactNativeBiometrics.swift
@@ -596,14 +596,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
     
     // Query to find the key
     var query = createKeychainQuery(keyTag: keyTag, includeSecureEnclave: false)
-    // Use LAContext with interaction disabled instead of deprecated kSecUseAuthenticationUIFail
-    if #available(iOS 16.0, *) {
-      let noUIContext = LAContext()
-      noUIContext.interactionNotAllowed = true
-      query[kSecUseAuthenticationContext as String] = noUIContext
-    } else {
-      query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
-    }
+    applyNoInteractionContext(&query)
     
     // Check if key exists first
     let checkStatus = SecItemCopyMatching(query as CFDictionary, nil)
@@ -671,6 +664,11 @@ class ReactNativeBiometrics: RCTEventEmitter {
       if status == errSecItemNotFound {
         ReactNativeBiometricDebug.debugLog("getPublicKey failed - Key not found")
         handleError(.keyNotFound, reject: reject)
+      } else if status == errSecInteractionNotAllowed {
+        // Auth-gated keys can refuse even a no-interaction ref lookup; the
+        // public key is then only obtainable from the createKeys result.
+        ReactNativeBiometricDebug.debugLog("getPublicKey failed - Key requires user authentication")
+        handleError(.keyRequiresAuthentication, reject: reject)
       } else {
         let biometricsError = ReactNativeBiometricsError.fromOSStatus(status)
         ReactNativeBiometricDebug.debugLog("getPublicKey failed - \(biometricsError.errorInfo.message)")
@@ -1433,14 +1431,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
       returnRef: true,
       returnAttributes: true
     )
-    // Use LAContext with interaction disabled instead of deprecated kSecUseAuthenticationUIFail
-    if #available(iOS 16.0, *) {
-      let noUIContext = LAContext()
-      noUIContext.interactionNotAllowed = true
-      secureEnclaveQuery[kSecUseAuthenticationContext as String] = noUIContext
-    } else {
-      secureEnclaveQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
-    }
+    applyNoInteractionContext(&secureEnclaveQuery)
     
     status = SecItemCopyMatching(secureEnclaveQuery as CFDictionary, &result)
     
@@ -1452,13 +1443,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
         returnRef: true,
         returnAttributes: true
       )
-      if #available(iOS 16.0, *) {
-        let noUIContext = LAContext()
-        noUIContext.interactionNotAllowed = true
-        regularQuery[kSecUseAuthenticationContext as String] = noUIContext
-      } else {
-        regularQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
-      }
+      applyNoInteractionContext(&regularQuery)
       
       status = SecItemCopyMatching(regularQuery as CFDictionary, &result)
     }

--- a/ios/ReactNativeBiometrics.swift
+++ b/ios/ReactNativeBiometrics.swift
@@ -432,13 +432,41 @@ class ReactNativeBiometrics: RCTEventEmitter {
                   failIfExists: NSNumber?,
                   resolver resolve: @escaping RCTPromiseResolveBlock,
                   rejecter reject: @escaping RCTPromiseRejectBlock) {
+    createKeysInternal(keyAlias: keyAlias as String?,
+                       keyType: keyType as String?,
+                       biometricStrength: biometricStrength as String?,
+                       allowDeviceCredentials: allowDeviceCredentials?.boolValue ?? false,
+                       failIfExists: failIfExists?.boolValue ?? false,
+                       requireAuthentication: true,
+                       resolve: resolve,
+                       reject: reject)
+  }
 
-    let deviceCredentialsFallback = allowDeviceCredentials?.boolValue ?? false
-    let failIfKeyExists = failIfExists?.boolValue ?? false
+  @objc
+  func createKeysWithOptions(_ options: NSDictionary,
+                             resolver resolve: @escaping RCTPromiseResolveBlock,
+                             rejecter reject: @escaping RCTPromiseRejectBlock) {
+    createKeysInternal(keyAlias: options["keyAlias"] as? String,
+                       keyType: options["keyType"] as? String,
+                       biometricStrength: options["biometricStrength"] as? String,
+                       allowDeviceCredentials: options["allowDeviceCredentials"] as? Bool ?? false,
+                       failIfExists: options["failIfExists"] as? Bool ?? false,
+                       requireAuthentication: options["requireAuthentication"] as? Bool ?? true,
+                       resolve: resolve,
+                       reject: reject)
+  }
 
-    ReactNativeBiometricDebug.debugLog("createKeys called with keyAlias: \(keyAlias ?? "default"), keyType: \(keyType ?? "ec256"), biometricStrength: \(biometricStrength ?? "strong"), allowDeviceCredentials: \(deviceCredentialsFallback), failIfExists: \(failIfKeyExists)")
+  private func createKeysInternal(keyAlias: String?,
+                                  keyType: String?,
+                                  biometricStrength: String?,
+                                  allowDeviceCredentials deviceCredentialsFallback: Bool,
+                                  failIfExists failIfKeyExists: Bool,
+                                  requireAuthentication: Bool,
+                                  resolve: @escaping RCTPromiseResolveBlock,
+                                  reject: @escaping RCTPromiseRejectBlock) {
+    ReactNativeBiometricDebug.debugLog("createKeys called with keyAlias: \(keyAlias ?? "default"), keyType: \(keyType ?? "ec256"), biometricStrength: \(biometricStrength ?? "strong"), allowDeviceCredentials: \(deviceCredentialsFallback), failIfExists: \(failIfKeyExists), requireAuthentication: \(requireAuthentication)")
 
-    let keyTag = getKeyAlias(keyAlias as String?)
+    let keyTag = getKeyAlias(keyAlias)
     guard let keyTagData = keyTag.data(using: .utf8) else {
       handleError(.dataEncodingFailed, reject: reject)
       return
@@ -446,7 +474,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
     
     // Parse key type
     let biometricKeyType: BiometricKeyType
-    if let keyTypeString = keyType as String?, keyTypeString.lowercased() == "rsa2048" {
+    if let keyTypeString = keyType, keyTypeString.lowercased() == "rsa2048" {
       biometricKeyType = .rsa2048
     } else {
       biometricKeyType = .ec256
@@ -455,7 +483,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
     // iOS migration-safe behavior:
     // - default/weak -> .biometryAny (backward-compatible with existing keys)
     // - strong       -> .biometryCurrentSet (invalidated on biometric enrollment change)
-    let biometricStrengthValue = (biometricStrength as String?)?.lowercased()
+    let biometricStrengthValue = biometricStrength?.lowercased()
     let useBiometryCurrentSet = biometricStrengthValue == "strong"
     
     // Check if key already exists when failIfExists is true
@@ -493,19 +521,28 @@ class ReactNativeBiometrics: RCTEventEmitter {
 
     ReactNativeBiometricDebug.debugLog("Deleted existing key (if any)")
     
-    // Create access control for biometric authentication
-    guard let accessControl = createBiometricAccessControl(
-      for: biometricKeyType,
-      allowDeviceCredentialsFallback: deviceCredentialsFallback,
-      useBiometryCurrentSet: useBiometryCurrentSet
-    ) else {
-      ReactNativeBiometricDebug.debugLog("createKeys failed - Could not create access control")
-      handleError(.accessControlCreationFailed, reject: reject)
-      return
-    }
-    
     // Key generation parameters
-    let keyAttributes = createKeyGenerationAttributes(keyTagData: keyTagData, accessControl: accessControl, keyType: biometricKeyType)
+    let keyAttributes: [String: Any]
+    if requireAuthentication {
+      // Create access control for biometric authentication
+      guard let accessControl = createBiometricAccessControl(
+        for: biometricKeyType,
+        allowDeviceCredentialsFallback: deviceCredentialsFallback,
+        useBiometryCurrentSet: useBiometryCurrentSet
+      ) else {
+        ReactNativeBiometricDebug.debugLog("createKeys failed - Could not create access control")
+        handleError(.accessControlCreationFailed, reject: reject)
+        return
+      }
+      keyAttributes = createKeyGenerationAttributes(keyTagData: keyTagData, accessControl: accessControl, keyType: biometricKeyType)
+    } else {
+      guard let noAuthAttributes = createNoAuthKeyGenerationAttributes(keyTagData: keyTagData, keyType: biometricKeyType) else {
+        ReactNativeBiometricDebug.debugLog("createKeys failed - Could not create no-auth key attributes")
+        handleError(.accessControlCreationFailed, reject: reject)
+        return
+      }
+      keyAttributes = noAuthAttributes
+    }
     
     var error: Unmanaged<CFError>?
     guard let privateKey = SecKeyCreateRandomKey(keyAttributes as CFDictionary, &error) else {
@@ -537,7 +574,7 @@ class ReactNativeBiometrics: RCTEventEmitter {
       "publicKey": publicKeyBase64
     ]
 
-    let shouldPersistBiometricDomainState = !deviceCredentialsFallback && useBiometryCurrentSet
+    let shouldPersistBiometricDomainState = requireAuthentication && !deviceCredentialsFallback && useBiometryCurrentSet
 
     if !shouldPersistBiometricDomainState {
       clearStoredBiometricDomainState(for: keyTag)
@@ -608,6 +645,62 @@ class ReactNativeBiometrics: RCTEventEmitter {
     }
   }
   
+  @objc
+  func getPublicKey(_ keyAlias: NSString?,
+                    resolver resolve: @escaping RCTPromiseResolveBlock,
+                    rejecter reject: @escaping RCTPromiseRejectBlock) {
+    ReactNativeBiometricDebug.debugLog("getPublicKey called with keyAlias: \(keyAlias ?? "default")")
+
+    let keyTag = getKeyAlias(keyAlias as String?)
+
+    // Try to find the key - first with Secure Enclave (for EC keys), then without (for RSA keys)
+    var result: CFTypeRef?
+    var status: OSStatus
+
+    var secureEnclaveQuery = createKeychainQuery(keyTag: keyTag, includeSecureEnclave: true, returnRef: true)
+    applyNoInteractionContext(&secureEnclaveQuery)
+    status = SecItemCopyMatching(secureEnclaveQuery as CFDictionary, &result)
+
+    if status == errSecItemNotFound {
+      var regularQuery = createKeychainQuery(keyTag: keyTag, includeSecureEnclave: false, returnRef: true)
+      applyNoInteractionContext(&regularQuery)
+      status = SecItemCopyMatching(regularQuery as CFDictionary, &result)
+    }
+
+    guard status == errSecSuccess else {
+      if status == errSecItemNotFound {
+        ReactNativeBiometricDebug.debugLog("getPublicKey failed - Key not found")
+        handleError(.keyNotFound, reject: reject)
+      } else {
+        let biometricsError = ReactNativeBiometricsError.fromOSStatus(status)
+        ReactNativeBiometricDebug.debugLog("getPublicKey failed - \(biometricsError.errorInfo.message)")
+        handleError(biometricsError, reject: reject)
+      }
+      return
+    }
+
+    // Force cast SecKey since conditional downcast to CoreFoundation types always succeeds
+    let keyRef = result as! SecKey
+
+    guard let publicKey = SecKeyCopyPublicKey(keyRef) else {
+      ReactNativeBiometricDebug.debugLog("getPublicKey failed - Could not extract public key")
+      handleError(.publicKeyExtractionFailed, reject: reject)
+      return
+    }
+
+    guard let publicKeyBase64 = exportPublicKeyToSPKIBase64(publicKey) else {
+      ReactNativeBiometricDebug.debugLog("getPublicKey failed - Public key export error")
+      handleError(.keyExportFailed, reject: reject)
+      return
+    }
+
+    let keyAttributes = SecKeyCopyAttributes(keyRef) as? [String: Any] ?? [:]
+    let isRSA = (keyAttributes[kSecAttrKeyType as String] as? String ?? "") == kSecAttrKeyTypeRSA as String
+
+    ReactNativeBiometricDebug.debugLog("getPublicKey completed successfully")
+    resolve(["publicKey": publicKeyBase64, "keyType": isRSA ? "rsa2048" : "ec256"])
+  }
+
   @objc
   func getAllKeys(_ customAlias: NSString?,
                   resolver resolve: @escaping RCTPromiseResolveBlock,
@@ -1090,7 +1183,118 @@ class ReactNativeBiometrics: RCTEventEmitter {
     // Device path (simulators return before #endif)
     performSign()
   }
-  
+
+  /**
+   * Signs data without any user authentication prompt. Only works with keys
+   * created with requireAuthentication = false; auth-bound keys resolve with
+   * KEY_REQUIRES_AUTHENTICATION instead of prompting.
+   */
+  @objc
+  func signData(_ options: NSDictionary,
+                resolver resolve: @escaping RCTPromiseResolveBlock,
+                rejecter reject: @escaping RCTPromiseRejectBlock) {
+    let keyAlias = options["keyAlias"] as? String
+    let encoding = (options["inputEncoding"] as? String ?? "utf8").lowercased()
+    let requestedAlgorithm = options["algorithm"] as? String
+
+    ReactNativeBiometricDebug.debugLog("signData called with keyAlias: \(keyAlias ?? "default"), inputEncoding: \(encoding), algorithm: \(requestedAlgorithm ?? "default")")
+
+    guard let data = options["data"] as? String else {
+      resolve(["success": false, "error": "No data provided", "errorCode": "INVALID_INPUT"])
+      return
+    }
+
+    let keyTag = getKeyAlias(keyAlias)
+
+    // Try to find the key - first with Secure Enclave (for EC keys), then
+    // without (for RSA keys). Interaction is disabled so an auth-gated key
+    // errors instead of prompting.
+    var result: CFTypeRef?
+    var status: OSStatus
+
+    var secureEnclaveQuery = createKeychainQuery(keyTag: keyTag, includeSecureEnclave: true, returnRef: true)
+    applyNoInteractionContext(&secureEnclaveQuery)
+    status = SecItemCopyMatching(secureEnclaveQuery as CFDictionary, &result)
+
+    if status == errSecItemNotFound {
+      var regularQuery = createKeychainQuery(keyTag: keyTag, includeSecureEnclave: false, returnRef: true)
+      applyNoInteractionContext(&regularQuery)
+      status = SecItemCopyMatching(regularQuery as CFDictionary, &result)
+    }
+
+    guard status == errSecSuccess else {
+      if status == errSecItemNotFound {
+        resolve(["success": false, "error": "Key not found", "errorCode": "KEY_NOT_FOUND"])
+      } else if status == errSecInteractionNotAllowed {
+        resolve(["success": false, "error": "Key requires user authentication. Use signWithOptions() instead.", "errorCode": "KEY_REQUIRES_AUTHENTICATION"])
+      } else {
+        let biometricsError = ReactNativeBiometricsError.fromOSStatus(status)
+        ReactNativeBiometricDebug.debugLog("signData failed - \(biometricsError.errorInfo.message)")
+        resolve(["success": false, "error": biometricsError.errorInfo.message, "errorCode": biometricsError.errorInfo.code])
+      }
+      return
+    }
+
+    // Force cast SecKey since conditional downcast to CoreFoundation types always succeeds
+    let keyRef = result as! SecKey
+
+    let algorithm: SecKeyAlgorithm
+    switch resolveSignatureAlgorithm(for: keyRef, requested: requestedAlgorithm) {
+    case .algorithm(let resolved):
+      algorithm = resolved
+    case .invalid(let message):
+      ReactNativeBiometricDebug.debugLog("signData failed - \(message)")
+      resolve(["success": false, "error": message, "errorCode": "INVALID_ALGORITHM"])
+      return
+    }
+
+    guard SecKeyIsAlgorithmSupported(keyRef, .sign, algorithm) else {
+      ReactNativeBiometricDebug.debugLog("signData failed - Key does not support the requested algorithm")
+      resolve(["success": false, "error": "Key does not support the requested algorithm", "errorCode": "UNSUPPORTED_ALGORITHM"])
+      return
+    }
+
+    // Decode data based on input encoding
+    let dataToSign: Data
+    if encoding == "base64" {
+      guard let decodedData = Data(base64Encoded: data) else {
+        ReactNativeBiometricDebug.debugLog("signData failed - Invalid base64 data")
+        resolve(["success": false, "error": "Invalid base64 data", "errorCode": "INVALID_INPUT_ENCODING"])
+        return
+      }
+      dataToSign = decodedData
+    } else {
+      guard let utf8Data = data.data(using: .utf8) else {
+        handleError(.dataEncodingFailed, reject: reject)
+        return
+      }
+      dataToSign = utf8Data
+    }
+
+    var error: Unmanaged<CFError>?
+    guard let signature = SecKeyCreateSignature(keyRef, algorithm, dataToSign as CFData, &error) else {
+      if let cfError = error?.takeRetainedValue() {
+        ReactNativeBiometricDebug.debugLog("signData failed - \(cfError.localizedDescription)")
+        let errorCode = CFErrorGetCode(cfError)
+        // An auth-gated key that survived the no-interaction lookup still
+        // fails here rather than prompting, because the no-UI context from
+        // the lookup governs the key's authorization.
+        if errorCode == Int(errSecInteractionNotAllowed) || (cfError as Error) is LAError {
+          resolve(["success": false, "error": "Key requires user authentication. Use signWithOptions() instead.", "errorCode": "KEY_REQUIRES_AUTHENTICATION"])
+          return
+        }
+      } else {
+        ReactNativeBiometricDebug.debugLog("signData failed - Signature creation failed (unknown error)")
+      }
+      let biometricsError = ReactNativeBiometricsError.signatureCreationFailed
+      resolve(["success": false, "error": biometricsError.errorInfo.message, "errorCode": biometricsError.errorInfo.code])
+      return
+    }
+
+    ReactNativeBiometricDebug.debugLog("signData completed successfully")
+    resolve(["success": true, "signature": (signature as Data).base64EncodedString()])
+  }
+
   @objc
   func validateSignature(_ keyAlias: NSString?,
                          data: NSString,

--- a/ios/ReactNativeBiometricsBridge.mm
+++ b/ios/ReactNativeBiometricsBridge.mm
@@ -26,6 +26,21 @@ RCT_EXTERN_METHOD(createKeys:
     resolver:(RCTPromiseResolveBlock)resolve
     rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(createKeysWithOptions:
+    (NSDictionary *)options
+    resolver:(RCTPromiseResolveBlock)resolve
+    rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getPublicKey:
+    (NSString *)keyAlias
+    resolver:(RCTPromiseResolveBlock)resolve
+    rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(signData:
+    (NSDictionary *)options
+    resolver:(RCTPromiseResolveBlock)resolve
+    rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(deleteKeys:
     (NSString *)keyAlias
     resolver:(RCTPromiseResolveBlock)resolve

--- a/ios/ReactNativeBiometricsError.swift
+++ b/ios/ReactNativeBiometricsError.swift
@@ -24,6 +24,7 @@ public enum ReactNativeBiometricsError: Error {
   case biometryDisconnected
 
   case keyNotFound
+  case keyRequiresAuthentication
   case keyCreationFailed
   case keyAlreadyExists
   case keyDeletionFailed
@@ -102,6 +103,8 @@ public enum ReactNativeBiometricsError: Error {
       // Key Management Errors
     case .keyNotFound:
       return ("KEY_NOT_FOUND", "Cryptographic key not found")
+    case .keyRequiresAuthentication:
+      return ("KEY_REQUIRES_AUTHENTICATION", "Key requires user authentication")
     case .keyCreationFailed:
       return ("KEY_CREATION_FAILED", "Failed to create cryptographic key")
     case .keyAlreadyExists:

--- a/ios/Utils.swift
+++ b/ios/Utils.swift
@@ -20,6 +20,44 @@ public func getSignatureAlgorithm(for keyRef: SecKey) -> SecKeyAlgorithm {
 }
 
 /**
+ * Result of resolving a requested signature algorithm name against a key
+ */
+public enum SignatureAlgorithmResolution {
+  case algorithm(SecKeyAlgorithm)
+  case invalid(message: String)
+}
+
+/**
+ * Resolves the SecKeyAlgorithm for a key from an optional requested algorithm
+ * name (SHA256withRSA / SHA512withRSA / SHA256withECDSA / SHA512withECDSA).
+ * Falls back to the SHA-256 default for the key type when nothing is requested.
+ */
+public func resolveSignatureAlgorithm(for keyRef: SecKey, requested: String?) -> SignatureAlgorithmResolution {
+  guard let requested = requested else {
+    return .algorithm(getSignatureAlgorithm(for: keyRef))
+  }
+
+  let keyAttributes = SecKeyCopyAttributes(keyRef) as? [String: Any] ?? [:]
+  let isRSA = (keyAttributes[kSecAttrKeyType as String] as? String ?? "") == kSecAttrKeyTypeRSA as String
+
+  switch (requested, isRSA) {
+  case ("SHA256withRSA", true):
+    return .algorithm(.rsaSignatureMessagePKCS1v15SHA256)
+  case ("SHA512withRSA", true):
+    return .algorithm(.rsaSignatureMessagePKCS1v15SHA512)
+  case ("SHA256withECDSA", false):
+    return .algorithm(.ecdsaSignatureMessageX962SHA256)
+  case ("SHA512withECDSA", false):
+    return .algorithm(.ecdsaSignatureMessageX962SHA512)
+  case ("SHA256withRSA", false), ("SHA512withRSA", false),
+       ("SHA256withECDSA", true), ("SHA512withECDSA", true):
+    return .invalid(message: "Algorithm \(requested) does not match the key type")
+  default:
+    return .invalid(message: "Unsupported algorithm: \(requested). Supported: SHA256withRSA, SHA512withRSA, SHA256withECDSA, SHA512withECDSA")
+  }
+}
+
+/**
  * Performs biometric authentication with consistent error handling
  * - Parameters:
  *   - reason: The localized reason for authentication
@@ -152,6 +190,20 @@ public func createKeychainQuery(
 }
 
 /**
+ * Disables authentication UI on a keychain query so lookups never prompt —
+ * an auth-gated key surfaces as errSecInteractionNotAllowed instead.
+ */
+public func applyNoInteractionContext(_ query: inout [String: Any]) {
+  if #available(iOS 16.0, *) {
+    let noUIContext = LAContext()
+    noUIContext.interactionNotAllowed = true
+    query[kSecUseAuthenticationContext as String] = noUIContext
+  } else {
+    query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
+  }
+}
+
+/**
  * Creates access control for biometric authentication
  * - Parameters:
  *   - keyType: The type of key being created
@@ -253,6 +305,67 @@ public func createKeyGenerationAttributes(
 }
 
 /**
+ * Creates key generation attributes for keys that do NOT require user
+ * authentication. The private key stays non-exportable and hardware-backed
+ * (Secure Enclave for EC keys on device), but using it never prompts.
+ *
+ * kSecAttrAccessibleWhenUnlockedThisDeviceOnly keeps the key device-bound
+ * without depending on a passcode being set (unlike the biometric path's
+ * WhenPasscodeSetThisDeviceOnly). Secure Enclave keys must still carry an
+ * access control, so they get one with only .privateKeyUsage — no biometry
+ * or user-presence constraint.
+ * - Returns: Key generation attributes dictionary, or nil if the required
+ *   access control could not be created
+ */
+public func createNoAuthKeyGenerationAttributes(
+  keyTagData: Data,
+  keyType: BiometricKeyType
+) -> [String: Any]? {
+  switch keyType {
+  case .rsa2048:
+    return [
+      kSecClass as String: kSecClassKey,
+      kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+      kSecAttrKeySizeInBits as String: 2048,
+      kSecPrivateKeyAttrs as String: [
+        kSecAttrIsPermanent as String: true,
+        kSecAttrApplicationTag as String: keyTagData,
+        kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+      ]
+    ]
+
+  case .ec256:
+    var privateKeyAttrs: [String: Any] = [
+      kSecAttrIsPermanent as String: true,
+      kSecAttrApplicationTag as String: keyTagData
+    ]
+    #if targetEnvironment(simulator)
+    privateKeyAttrs[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    #else
+    guard let accessControl = SecAccessControlCreateWithFlags(
+      kCFAllocatorDefault,
+      kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+      [.privateKeyUsage],
+      nil
+    ) else {
+      return nil
+    }
+    privateKeyAttrs[kSecAttrAccessControl as String] = accessControl
+    #endif
+
+    var attributes: [String: Any] = [
+      kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+      kSecAttrKeySizeInBits as String: 256,
+      kSecPrivateKeyAttrs as String: privateKeyAttrs
+    ]
+    #if !targetEnvironment(simulator)
+    attributes[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
+    #endif
+    return attributes
+  }
+}
+
+/**
  * SPKI (Subject Public Key Info) header for EC P-256 (secp256r1) keys.
  * This ASN.1 header is required for standard X.509 SubjectPublicKeyInfo format
  * and compatibility with the old react-native-biometrics library.
@@ -309,6 +422,71 @@ public func exportPublicKeyToBase64(_ publicKey: SecKey) -> String? {
     ReactNativeBiometricDebug.debugLog("Exported public key (\(rawKeyData.count) bytes)")
     return rawKeyData.base64EncodedString()
   }
+}
+
+/**
+ * Encodes an ASN.1 DER length field (short or long form).
+ */
+private func derLength(_ length: Int) -> [UInt8] {
+  if length < 0x80 {
+    return [UInt8(length)]
+  }
+  var bytes: [UInt8] = []
+  var value = length
+  while value > 0 {
+    bytes.insert(UInt8(value & 0xFF), at: 0)
+    value >>= 8
+  }
+  return [0x80 | UInt8(bytes.count)] + bytes
+}
+
+/**
+ * Exports a public key as base64 X.509 SubjectPublicKeyInfo DER for all key
+ * types. EC P-256 reuses the fixed SPKI header; RSA wraps the PKCS#1 output
+ * of SecKeyCopyExternalRepresentation in a computed SPKI envelope:
+ *   SEQUENCE {
+ *     SEQUENCE { OID 1.2.840.113549.1.1.1 (rsaEncryption), NULL }
+ *     BIT STRING { PKCS#1 RSAPublicKey }
+ *   }
+ * Unlike exportPublicKeyToBase64 (kept for backward compatibility of
+ * createKeys output), the result is directly consumable by standard tooling.
+ */
+public func exportPublicKeyToSPKIBase64(_ publicKey: SecKey) -> String? {
+  var error: Unmanaged<CFError>?
+  guard let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) else {
+    if let cfError = error?.takeRetainedValue() {
+      ReactNativeBiometricDebug.debugLog("Public key export error: \(cfError.localizedDescription)")
+    }
+    return nil
+  }
+
+  let rawKeyData = publicKeyData as Data
+
+  if rawKeyData.count == 65 && rawKeyData[0] == 0x04 {
+    var spkiData = Data(ecP256SPKIHeader)
+    spkiData.append(rawKeyData)
+    ReactNativeBiometricDebug.debugLog("Exported EC P-256 public key as SPKI (\(spkiData.count) bytes)")
+    return spkiData.base64EncodedString()
+  }
+
+  let rsaAlgorithmIdentifier: [UInt8] = [
+    0x30, 0x0D,        // SEQUENCE, length 13
+    0x06, 0x09,        // OID, length 9
+    0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,  // 1.2.840.113549.1.1.1 (rsaEncryption)
+    0x05, 0x00         // NULL
+  ]
+  var bitString: [UInt8] = [0x03]
+  bitString += derLength(rawKeyData.count + 1)
+  bitString.append(0x00)  // unused bits
+  bitString += [UInt8](rawKeyData)
+
+  var spki: [UInt8] = [0x30]
+  spki += derLength(rsaAlgorithmIdentifier.count + bitString.count)
+  spki += rsaAlgorithmIdentifier
+  spki += bitString
+
+  ReactNativeBiometricDebug.debugLog("Exported RSA public key as SPKI (\(spki.count) bytes)")
+  return Data(spki).base64EncodedString()
 }
 
 #if targetEnvironment(simulator)

--- a/src/NativeReactNativeBiometrics.ts
+++ b/src/NativeReactNativeBiometrics.ts
@@ -54,6 +54,31 @@ export interface Spec extends TurboModule {
   ): Promise<{
     publicKey: string;
   }>;
+  createKeysWithOptions(options: {
+    keyAlias?: string;
+    keyType?: string;
+    requireAuthentication?: boolean;
+    biometricStrength?: 'weak' | 'strong';
+    allowDeviceCredentials?: boolean;
+    failIfExists?: boolean;
+  }): Promise<{
+    publicKey: string;
+  }>;
+  getPublicKey(keyAlias?: string | null): Promise<{
+    publicKey: string;
+    keyType?: string;
+  }>;
+  signData(options: {
+    keyAlias?: string;
+    data: string;
+    inputEncoding?: 'utf8' | 'base64';
+    algorithm?: string;
+  }): Promise<{
+    success: boolean;
+    signature?: string;
+    error?: string;
+    errorCode?: string;
+  }>;
   deleteKeys(keyAlias?: string | null): Promise<{
     success: boolean;
   }>;

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -128,6 +128,16 @@ jest.mock('../NativeReactNativeBiometrics', () => ({
   verifyKeySignatureWithEncoding: jest.fn(() =>
     Promise.resolve({ success: true, signature: 'mockSig', authType: 3 })
   ),
+  getKeyAttributes: jest.fn(() => Promise.resolve({ exists: true })),
+  createKeysWithOptions: jest.fn(() =>
+    Promise.resolve({ publicKey: 'mockPublicKey' })
+  ),
+  getPublicKey: jest.fn(() =>
+    Promise.resolve({ publicKey: 'mockSpkiKey', keyType: 'rsa2048' })
+  ),
+  signData: jest.fn(() =>
+    Promise.resolve({ success: true, signature: 'mockSig' })
+  ),
 }));
 
 // Helper function to create custom mocks for error scenarios
@@ -168,6 +178,16 @@ const createMockNative = (overrides = {}) => ({
   ),
   verifyKeySignatureWithEncoding: jest.fn(() =>
     Promise.resolve({ success: true, signature: 'mockSig', authType: 3 })
+  ),
+  getKeyAttributes: jest.fn(() => Promise.resolve({ exists: true })),
+  createKeysWithOptions: jest.fn(() =>
+    Promise.resolve({ publicKey: 'mockPublicKey' })
+  ),
+  getPublicKey: jest.fn(() =>
+    Promise.resolve({ publicKey: 'mockSpkiKey', keyType: 'rsa2048' })
+  ),
+  signData: jest.fn(() =>
+    Promise.resolve({ success: true, signature: 'mockSig' })
   ),
   ...overrides,
 });
@@ -1060,6 +1080,196 @@ describe('ReactNativeBiometrics', () => {
       expect(result.success).toBe(true);
       expect(result).toHaveProperty('authType');
       expect(result.authType).toBe(3);
+    });
+  });
+});
+
+describe('Non-Biometric Signing', () => {
+  // Grab the mock instance the static Biometrics import is bound to; this
+  // runs at collection time, before any jest.resetModules() in earlier tests.
+  const NativeBiometrics: any = jest.requireMock(
+    '../NativeReactNativeBiometrics'
+  );
+
+  describe('createKeysWithOptions', () => {
+    it('applies defaults when called without options', async () => {
+      const result = await Biometrics.createKeysWithOptions();
+      expect(result).toEqual(MOCK_RESPONSES.keyCreation);
+      expect(NativeBiometrics.createKeysWithOptions).toHaveBeenLastCalledWith({
+        keyAlias: undefined,
+        keyType: undefined,
+        requireAuthentication: true,
+        biometricStrength: undefined,
+        allowDeviceCredentials: false,
+        failIfExists: false,
+      });
+    });
+
+    it('forwards options for an auth-required key', async () => {
+      await Biometrics.createKeysWithOptions({
+        keyAlias: 'testAlias',
+        keyType: 'ec256',
+        biometricStrength: Biometrics.BiometricStrength.Strong,
+        allowDeviceCredentials: true,
+        failIfExists: true,
+      });
+      expect(NativeBiometrics.createKeysWithOptions).toHaveBeenLastCalledWith({
+        keyAlias: 'testAlias',
+        keyType: 'ec256',
+        requireAuthentication: true,
+        biometricStrength: 'strong',
+        allowDeviceCredentials: true,
+        failIfExists: true,
+      });
+    });
+
+    it('strips auth-only options when requireAuthentication is false', async () => {
+      await Biometrics.createKeysWithOptions({
+        keyAlias: 'noauth',
+        keyType: 'rsa2048',
+        requireAuthentication: false,
+        biometricStrength: Biometrics.BiometricStrength.Strong,
+        allowDeviceCredentials: true,
+      });
+      expect(NativeBiometrics.createKeysWithOptions).toHaveBeenLastCalledWith({
+        keyAlias: 'noauth',
+        keyType: 'rsa2048',
+        requireAuthentication: false,
+        biometricStrength: undefined,
+        allowDeviceCredentials: false,
+        failIfExists: false,
+      });
+    });
+
+    it('normalizes an empty-string alias to undefined', async () => {
+      await Biometrics.createKeysWithOptions({ keyAlias: '' });
+      expect(NativeBiometrics.createKeysWithOptions).toHaveBeenLastCalledWith(
+        expect.objectContaining({ keyAlias: undefined })
+      );
+    });
+
+    it('propagates native rejections', async () => {
+      NativeBiometrics.createKeysWithOptions.mockRejectedValueOnce(
+        new Error('Key generation failed')
+      );
+      await expect(Biometrics.createKeysWithOptions()).rejects.toThrow(
+        'Key generation failed'
+      );
+    });
+  });
+
+  describe('keyExists', () => {
+    it('resolves true when the key exists', async () => {
+      NativeBiometrics.getKeyAttributes.mockResolvedValueOnce({
+        exists: true,
+        attributes: { algorithm: 'RSA' },
+      });
+      await expect(Biometrics.keyExists('testAlias')).resolves.toBe(true);
+      expect(NativeBiometrics.getKeyAttributes).toHaveBeenLastCalledWith(
+        'testAlias'
+      );
+    });
+
+    it('resolves false when the key does not exist', async () => {
+      NativeBiometrics.getKeyAttributes.mockResolvedValueOnce({
+        exists: false,
+      });
+      await expect(Biometrics.keyExists('missing')).resolves.toBe(false);
+    });
+
+    it('normalizes an empty-string alias to undefined', async () => {
+      await Biometrics.keyExists('');
+      expect(NativeBiometrics.getKeyAttributes).toHaveBeenLastCalledWith(
+        undefined
+      );
+    });
+
+    it('propagates native rejections', async () => {
+      NativeBiometrics.getKeyAttributes.mockRejectedValueOnce(
+        new Error('Keystore unavailable')
+      );
+      await expect(Biometrics.keyExists()).rejects.toThrow(
+        'Keystore unavailable'
+      );
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('returns the public key for an alias', async () => {
+      const result = await Biometrics.getPublicKey('testAlias');
+      expect(result).toEqual({
+        publicKey: 'mockSpkiKey',
+        keyType: 'rsa2048',
+      });
+      expect(NativeBiometrics.getPublicKey).toHaveBeenLastCalledWith(
+        'testAlias'
+      );
+    });
+
+    it('uses the default alias when none is given', async () => {
+      await Biometrics.getPublicKey();
+      expect(NativeBiometrics.getPublicKey).toHaveBeenLastCalledWith(undefined);
+    });
+
+    it('propagates KEY_NOT_FOUND rejections', async () => {
+      NativeBiometrics.getPublicKey.mockRejectedValueOnce(
+        new Error('Key not found')
+      );
+      await expect(Biometrics.getPublicKey('missing')).rejects.toThrow(
+        'Key not found'
+      );
+    });
+  });
+
+  describe('sign', () => {
+    it('signs with the default utf8 encoding and no explicit algorithm', async () => {
+      const result = await Biometrics.sign({ data: 'payload' });
+      expect(result).toEqual({ success: true, signature: 'mockSig' });
+      expect(NativeBiometrics.signData).toHaveBeenLastCalledWith({
+        keyAlias: undefined,
+        data: 'payload',
+        inputEncoding: 'utf8',
+        algorithm: undefined,
+      });
+    });
+
+    it('forwards alias, encoding and algorithm', async () => {
+      await Biometrics.sign({
+        keyAlias: 'noauth',
+        data: 'cGF5bG9hZA==',
+        inputEncoding: Biometrics.InputEncoding.Base64,
+        algorithm: Biometrics.SignatureAlgorithm.SHA512withRSA,
+      });
+      expect(NativeBiometrics.signData).toHaveBeenLastCalledWith({
+        keyAlias: 'noauth',
+        data: 'cGF5bG9hZA==',
+        inputEncoding: 'base64',
+        algorithm: 'SHA512withRSA',
+      });
+    });
+
+    it('passes through KEY_REQUIRES_AUTHENTICATION results unmodified', async () => {
+      NativeBiometrics.signData.mockResolvedValueOnce({
+        success: false,
+        error:
+          'Key requires user authentication. Use signWithOptions() instead.',
+        errorCode: 'KEY_REQUIRES_AUTHENTICATION',
+      });
+      const result = await Biometrics.sign({
+        keyAlias: 'biometric-key',
+        data: 'payload',
+      });
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('KEY_REQUIRES_AUTHENTICATION');
+    });
+
+    it('propagates native rejections', async () => {
+      NativeBiometrics.signData.mockRejectedValueOnce(
+        new Error('Native failure')
+      );
+      await expect(Biometrics.sign({ data: 'payload' })).rejects.toThrow(
+        'Native failure'
+      );
     });
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -639,7 +639,11 @@ export function keyExists(keyAlias?: string): Promise<boolean> {
  * both key types, so it can be consumed directly by standard tooling
  * (e.g. `openssl pkey -pubin -inform DER`).
  *
- * Rejects with code `KEY_NOT_FOUND` if no key exists for the alias.
+ * Rejects with code `KEY_NOT_FOUND` if no key exists for the alias. On iOS,
+ * a biometric-gated key may reject with `KEY_REQUIRES_AUTHENTICATION`
+ * because the Keychain can refuse even a non-interactive lookup of an
+ * auth-bound key — capture the `publicKey` from {@link createKeys} at
+ * creation time for those keys (Android is unaffected).
  */
 export function getPublicKey(keyAlias?: string): Promise<PublicKeyResult> {
   logger.debug('Getting public key', 'getPublicKey', { keyAlias });
@@ -888,7 +892,9 @@ export type CreateKeysOptions = {
    * When true (default), using the private key requires user authentication —
    * the existing biometric-gated behavior. When false, the key is created
    * without any user-authentication requirement so {@link sign} works without
-   * a prompt. The private key remains hardware-backed and non-exportable.
+   * a prompt. The private key remains non-exportable in the Keystore/Keychain
+   * and is hardware-backed where supported (Android TEE/StrongBox, iOS Secure
+   * Enclave for EC keys; iOS RSA keys reside in the regular Keychain).
    */
   requireAuthentication?: boolean;
   /** Ignored when requireAuthentication is false. (Android only) */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -216,6 +216,83 @@ export function createKeys(
     });
 }
 
+/**
+ * Creates a key pair using an options object, with control over whether the
+ * key requires user authentication.
+ *
+ * With `requireAuthentication: false` the key can sign without any biometric
+ * or device-credential prompt (see {@link sign}), while the private key still
+ * never leaves the Android Keystore / iOS Keychain (Secure Enclave for EC
+ * keys on device). Defaults preserve the behavior of {@link createKeys}:
+ * keys are biometric-gated.
+ *
+ * @example
+ * // Hardware-backed key usable without a biometric prompt
+ * const { publicKey } = await createKeysWithOptions({
+ *   keyAlias: 'server-auth-key',
+ *   keyType: 'rsa2048',
+ *   requireAuthentication: false,
+ * });
+ */
+export function createKeysWithOptions(
+  options: CreateKeysOptions = {}
+): Promise<KeyCreationResult> {
+  const {
+    keyAlias,
+    keyType,
+    requireAuthentication = true,
+    biometricStrength,
+    allowDeviceCredentials = false,
+    failIfExists = false,
+  } = options;
+
+  if (
+    !requireAuthentication &&
+    (biometricStrength !== undefined || allowDeviceCredentials)
+  ) {
+    logger.debug(
+      'biometricStrength and allowDeviceCredentials are ignored when requireAuthentication is false',
+      'createKeysWithOptions'
+    );
+  }
+
+  logger.debug('Creating keys with options', 'createKeysWithOptions', {
+    keyAlias,
+    keyType,
+    requireAuthentication,
+    biometricStrength,
+    allowDeviceCredentials,
+    failIfExists,
+  });
+  return ReactNativeBiometrics.createKeysWithOptions({
+    keyAlias: keyAlias || undefined,
+    keyType,
+    requireAuthentication,
+    biometricStrength: requireAuthentication ? biometricStrength : undefined,
+    allowDeviceCredentials: requireAuthentication
+      ? allowDeviceCredentials
+      : false,
+    failIfExists,
+  })
+    .then((result) => {
+      logger.info('Keys created successfully', 'createKeysWithOptions', {
+        keyAlias,
+        keyType,
+        requireAuthentication,
+        publicKeyLength: result.publicKey?.length,
+      });
+      return result;
+    })
+    .catch((error) => {
+      logger.error('Key creation failed', 'createKeysWithOptions', error, {
+        keyAlias,
+        keyType,
+        requireAuthentication,
+      });
+      throw error;
+    });
+}
+
 export function deleteKeys(keyAlias?: string): Promise<KeyDeletionResult> {
   logger.debug('Deleting biometric keys', 'deleteKeys', { keyAlias });
   return ReactNativeBiometrics.deleteKeys(keyAlias)
@@ -416,6 +493,52 @@ export function signWithOptions(
     });
 }
 
+/**
+ * Signs data without any biometric or device-credential prompt.
+ *
+ * Only works with keys created via
+ * `createKeysWithOptions({ requireAuthentication: false })`. Calling it on a
+ * biometric-gated key never shows a prompt — it resolves with
+ * `{ success: false, errorCode: 'KEY_REQUIRES_AUTHENTICATION' }`; use
+ * {@link signWithOptions} for those keys instead.
+ *
+ * @example
+ * const result = await sign({
+ *   keyAlias: 'server-auth-key',
+ *   data: payload,
+ *   algorithm: SignatureAlgorithm.SHA512withRSA,
+ * });
+ */
+export function sign(options: SignOptions): Promise<SignatureResult> {
+  const { keyAlias, data, inputEncoding = 'utf8', algorithm } = options;
+
+  logger.debug('Signing data without authentication', 'sign', {
+    keyAlias,
+    dataLength: data.length,
+    inputEncoding,
+    algorithm,
+  });
+  return ReactNativeBiometrics.signData({
+    keyAlias: keyAlias || undefined,
+    data,
+    inputEncoding,
+    algorithm,
+  })
+    .then((result) => {
+      logger.info('Sign completed', 'sign', {
+        keyAlias,
+        success: result.success,
+        hasSignature: !!result.signature,
+        errorCode: result.errorCode,
+      });
+      return result;
+    })
+    .catch((error) => {
+      logger.error('Sign failed', 'sign', error, { keyAlias });
+      throw error;
+    });
+}
+
 export function validateSignature(
   keyAlias: string = '',
   data: string,
@@ -481,6 +604,58 @@ export function getKeyAttributes(
         error,
         { keyAlias }
       );
+      throw error;
+    });
+}
+
+/**
+ * Checks whether a key exists for the given alias without triggering any
+ * biometric prompt.
+ */
+export function keyExists(keyAlias?: string): Promise<boolean> {
+  logger.debug('Checking key existence', 'keyExists', { keyAlias });
+  return ReactNativeBiometrics.getKeyAttributes(keyAlias || undefined)
+    .then((result) => {
+      logger.info('Key existence check completed', 'keyExists', {
+        keyAlias,
+        exists: result.exists,
+      });
+      return result.exists;
+    })
+    .catch((error) => {
+      logger.error('Key existence check failed', 'keyExists', error, {
+        keyAlias,
+      });
+      throw error;
+    });
+}
+
+/**
+ * Retrieves the public key for the given alias without triggering any
+ * biometric prompt.
+ *
+ * Unlike the `publicKey` returned by {@link createKeys}, the result is
+ * base64-encoded X.509 SubjectPublicKeyInfo DER on both platforms and for
+ * both key types, so it can be consumed directly by standard tooling
+ * (e.g. `openssl pkey -pubin -inform DER`).
+ *
+ * Rejects with code `KEY_NOT_FOUND` if no key exists for the alias.
+ */
+export function getPublicKey(keyAlias?: string): Promise<PublicKeyResult> {
+  logger.debug('Getting public key', 'getPublicKey', { keyAlias });
+  return ReactNativeBiometrics.getPublicKey(keyAlias || undefined)
+    .then((result) => {
+      logger.info('Public key retrieved', 'getPublicKey', {
+        keyAlias,
+        keyType: result.keyType,
+        publicKeyLength: result.publicKey?.length,
+      });
+      return result;
+    })
+    .catch((error) => {
+      logger.error('Public key retrieval failed', 'getPublicKey', error, {
+        keyAlias,
+      });
       throw error;
     });
 }
@@ -701,6 +876,36 @@ export type KeyCreationResult = {
   publicKey: string;
 };
 
+/**
+ * Options for {@link createKeysWithOptions}.
+ */
+export type CreateKeysOptions = {
+  /** The key alias. Defaults to the configured alias. */
+  keyAlias?: string;
+  /** Key type: 'rsa2048' or 'ec256'. Platform default applies when omitted. */
+  keyType?: 'rsa2048' | 'ec256';
+  /**
+   * When true (default), using the private key requires user authentication —
+   * the existing biometric-gated behavior. When false, the key is created
+   * without any user-authentication requirement so {@link sign} works without
+   * a prompt. The private key remains hardware-backed and non-exportable.
+   */
+  requireAuthentication?: boolean;
+  /** Ignored when requireAuthentication is false. (Android only) */
+  biometricStrength?: BiometricStrength;
+  /** Ignored when requireAuthentication is false. */
+  allowDeviceCredentials?: boolean;
+  /** When true, rejects with KEY_ALREADY_EXISTS instead of replacing the key. */
+  failIfExists?: boolean;
+};
+
+export type PublicKeyResult = {
+  /** Base64-encoded X.509 SubjectPublicKeyInfo DER. */
+  publicKey: string;
+  /** 'rsa2048' or 'ec256' when the platform can determine it. */
+  keyType?: string;
+};
+
 export type KeyDeletionResult = {
   success: boolean;
 };
@@ -742,6 +947,40 @@ export enum InputEncoding {
   /** Data is base64-encoded binary - use for WebAuthn challenges or other binary data */
   Base64 = 'base64',
 }
+
+/**
+ * Signature algorithm for prompt-free signing via {@link sign}.
+ *
+ * Note: on Android, keys created before SHA-512 support was added (and keys
+ * generated inside StrongBox) only permit SHA-256 — requesting a SHA-512
+ * variant on such a key fails with UNSUPPORTED_ALGORITHM. On iOS the
+ * algorithm is chosen per call and works with existing keys.
+ */
+export enum SignatureAlgorithm {
+  SHA256withRSA = 'SHA256withRSA',
+  SHA512withRSA = 'SHA512withRSA',
+  SHA256withECDSA = 'SHA256withECDSA',
+  SHA512withECDSA = 'SHA512withECDSA',
+}
+
+/**
+ * Options for {@link sign} (prompt-free signing).
+ */
+export type SignOptions = {
+  /** The key alias to use for signing. Defaults to the configured alias. */
+  keyAlias?: string;
+  /** The data to sign */
+  data: string;
+  /** Encoding of the input data. Defaults to InputEncoding.UTF8. */
+  inputEncoding?: InputEncoding;
+  /**
+   * Signature algorithm. Defaults to the SHA-256 variant matching the key
+   * type (SHA256withRSA for RSA keys, SHA256withECDSA for EC keys). Must
+   * match the key type: requesting an RSA algorithm on an EC key (or vice
+   * versa) fails with INVALID_ALGORITHM.
+   */
+  algorithm?: SignatureAlgorithm;
+};
 
 /**
  * Options for signing data with advanced security controls.


### PR DESCRIPTION
## Summary

Implements the request in #90: hardware-backed signing **without biometric prompts** — a modern `react-native-rsa-native` replacement built on this library's existing secure-key core. Purely additive; the default biometric-gated behavior is untouched.

## New API (all prompt-free)

- `createKeysWithOptions({ keyAlias, keyType, requireAuthentication, ... })` — with `requireAuthentication: false` the key skips Android's `setUserAuthenticationRequired` and iOS's biometric access control while staying non-exportable in the Keystore/Keychain (Secure Enclave for EC keys on device; iOS uses `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`)
- `keyExists(alias)` — boolean existence check (makes the `keyExists()` already referenced in the docs real)
- `getPublicKey(alias)` — base64 X.509 SPKI DER on both platforms and both key types (normalizes the iOS-RSA PKCS#1 inconsistency; legacy `createKeys` output unchanged)
- `sign({ keyAlias, data, inputEncoding, algorithm })` — supports `SHA256withRSA`, `SHA512withRSA`, `SHA256withECDSA`, `SHA512withECDSA`; on a biometric-gated key it never prompts and resolves `{ success: false, errorCode: 'KEY_REQUIRES_AUTHENTICATION' }`

## Notable behaviors

- New Android TEE keys are minted with SHA-256 + SHA-512 digests; **StrongBox keys stay SHA-256-only** so listing SHA-512 can't silently demote them to TEE via the generation fallback. Existing Android keys remain SHA-256-only (`UNSUPPORTED_ALGORITHM` on SHA-512) — documented.
- `signWithOptions()` on a no-auth key signs silently with `authType: 0` (activates the previously unreachable direct-sign branch on Android).
- All three layers touched per the architecture: codegen spec, JS API + logging, Android shared impl + both arch modules, Swift + bridge.

## Testing

- 102 Jest tests pass (17 new), `yarn typecheck` and `yarn lint` clean
- Android Kotlin compiles via the example's gradle; the codegen'd `NativeReactNativeBiometricsSpec` matches the new-arch module overrides
- iOS library pod builds with `xcodebuild` (simulator, both slices)
- Example app gains a `NonBiometricSigningExample` screen covering the full flow plus the expected `KEY_REQUIRES_AUTHENTICATION` negative case — runtime verification on simulator/emulator/device still recommended before release

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable hardware-backed RSA and EC key creation with optional biometric or device-credential authentication.
  * Added prompt-free signing with UTF-8 or Base64 input and selectable RSA/ECDSA SHA-256 or SHA-512 algorithms.
  * Added key-existence checks and public-key retrieval in standard SPKI format.
  * Added clear handling for missing keys, invalid inputs, authentication requirements, and unsupported algorithms.
* **Documentation**
  * Added API guidance, usage examples, platform considerations, and cleanup instructions.
* **Examples & Tests**
  * Added an interactive non-biometric signing example and comprehensive coverage for the new APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->