### PR TITLE
feat: detect Frida/Xposed runtime hooks in device integrity status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,7 @@ console.log(`Found ${defaultKeys.keys.length} keys with default alias`);
 
 #### `getDeviceIntegrityStatus()`
 
-Checks the integrity and security status of the device, including detection of compromised devices (rooted/jailbroken).
+Checks the integrity and security status of the device, including detection of compromised devices (rooted/jailbroken) and active runtime instrumentation (Frida/Xposed).
 
 ```typescript
 const getDeviceIntegrityStatus = (): Promise<DeviceIntegrityResult> => {
@@ -1090,11 +1090,22 @@ type DeviceIntegrityResult = {
   hasSecureHardware?: boolean;  // 🤖 ANDROID ONLY: Whether secure hardware is available
 
   // Cross-platform properties
+  hasRuntimeHooks?: boolean;    // 🤖🍎 Whether an instrumentation framework (Frida, Xposed/LSPosed) is actively injected into the process
+  isDebuggerAttached?: boolean; // 🤖🍎 Whether a debugger is attached — informational only, does NOT affect isCompromised (debuggers are routine in development)
+  runtimeHookDetails?: {        // 🤖🍎 Per-framework breakdown of the hook detection
+    fridaDetected: boolean;     // 🤖🍎 Frida artifacts, mapped libraries, or default server port detected
+    xposedDetected?: boolean;   // 🤖 ANDROID ONLY: Xposed/EdXposed/LSPosed/Substrate detected
+  };
   isCompromised: boolean;       // 🤖🍎 Overall compromise status (always present)
   riskLevel: 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'UNKNOWN';  // 🤖🍎 Risk assessment (always present)
   error?: string;               // 🤖🍎 Error message if check failed
 }
 ```
+
+> [!NOTE]
+> **Runtime hook detection is best-effort.** Detected hooks set `isCompromised: true` and `riskLevel: 'HIGH'`, but a negative result is not proof of integrity: an attacker who already controls the runtime can hook the detection itself, rename binaries, or move frida-server off its default port. These checks raise the bar — for server-verifiable integrity signals, pair them with [Play Integrity](https://developer.android.com/google/play/integrity) (Android) and [App Attest](https://developer.apple.com/documentation/devicecheck) (iOS).
+>
+> Two environment notes: on Android the frida-server port probe requires the host app to hold `android.permission.INTERNET` (virtually all React Native apps do) — the library does not declare it for you, and without it that single probe silently reports nothing. On the iOS **Simulator**, localhost is shared with the macOS host, so a `frida-server` running on your Mac will register as a hook inside the simulator; verify hook detection on a physical device.
 
 **Example:**
 ```javascript
@@ -1116,6 +1127,10 @@ const checkDeviceSecurity = async () => {
       if (status.isJailbroken) {
         // IOS ONLY
         console.log('📱 Device is jailbroken');
+      }
+
+      if (status.hasRuntimeHooks) {
+        console.log('🪝 Runtime instrumentation detected:', status.runtimeHookDetails);
       }
 
       // Handle compromised device (e.g., restrict functionality)
@@ -1718,6 +1733,19 @@ The example app provides hands-on experience with all library features and serve
 - **"No biometric features available"**: Check if device has fingerprint sensor and it's enrolled
 - **"BiometricPrompt not available"**: Ensure Android API level 23+ and androidx.biometric dependency
 - **Permission denied**: Verify `USE_FINGERPRINT` and `USE_BIOMETRIC` permissions are added
+
+#### Native crash on 32-bit Android (armeabi-v7a) release builds
+
+If your app crashes on startup on 32-bit devices in release builds with a backtrace pointing at `JavaTurboModule::setEventEmitterCallback` / `NativeReactNativeBiometricsSpecJSI`, this is a React Native core bug ([facebook/react-native#51628](https://github.com/facebook/react-native/issues/51628)), not a bug in this library. RN used an unsafe variadic JNI call that misreads the stack on 32-bit ABIs; it is triggered by any TurboModule that declares an event emitter (this library's `onBiometricChange`). See [issue #89](https://github.com/sbaiahmed1/react-native-biometrics/issues/89) for the full analysis.
+
+**Fix**: upgrade React Native to a version containing [the upstream fix](https://github.com/facebook/react-native/pull/51695):
+
+| RN line | Affected | Fixed in |
+|---|---|---|
+| ≤ 0.78.x | all | never backported — upgrade to 0.79.6+ |
+| 0.79.x | 0.79.0 – 0.79.5 | 0.79.6 |
+| 0.80.x | 0.80.0 | 0.80.1 |
+| 0.81.x and later | — | not affected |
 
 ### Debug Mode
 

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/ReactNativeBiometricsSharedImpl.kt
@@ -1783,21 +1783,25 @@ class ReactNativeBiometricsSharedImpl(private val context: ReactApplicationConte
   fun getDeviceIntegrityStatus(promise: Promise) {
     debugLog("getDeviceIntegrityStatus called")
 
-    try {
-      val integrityStatus = BiometricUtils.getDeviceIntegrityStatus(context)
-      debugLog("Device integrity check completed - isCompromised: ${integrityStatus.getBoolean("isCompromised")}")
-      promise.resolve(integrityStatus)
-    } catch (e: Exception) {
-      debugLog("getDeviceIntegrityStatus failed - ${e.message}")
-      val errorResult = Arguments.createMap()
-      errorResult.putBoolean("isRooted", false)
-      errorResult.putBoolean("isKeyguardSecure", false)
-      errorResult.putBoolean("hasSecureHardware", false)
-      errorResult.putBoolean("isCompromised", true)
-      errorResult.putString("riskLevel", "UNKNOWN")
-      errorResult.putString("error", "Failed to check device integrity: ${e.message}")
-      promise.resolve(errorResult)
-    }
+    // The integrity checks block on getprop, /proc reads, and a localhost port
+    // probe (up to 300ms), so they must not run on the RN module thread.
+    Thread {
+      try {
+        val integrityStatus = BiometricUtils.getDeviceIntegrityStatus(context)
+        debugLog("Device integrity check completed - isCompromised: ${integrityStatus.getBoolean("isCompromised")}")
+        promise.resolve(integrityStatus)
+      } catch (e: Exception) {
+        debugLog("getDeviceIntegrityStatus failed - ${e.message}")
+        val errorResult = Arguments.createMap()
+        errorResult.putBoolean("isRooted", false)
+        errorResult.putBoolean("isKeyguardSecure", false)
+        errorResult.putBoolean("hasSecureHardware", false)
+        errorResult.putBoolean("isCompromised", true)
+        errorResult.putString("riskLevel", "UNKNOWN")
+        errorResult.putString("error", "Failed to check device integrity: ${e.message}")
+        promise.resolve(errorResult)
+      }
+    }.start()
   }
 
   /**

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/Utils.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/Utils.kt
@@ -572,8 +572,18 @@ object BiometricUtils {
      * "nothing detected", not proof of integrity.
      */
     fun detectFrida(): Boolean {
-        return checkFridaArtifacts() || checkProcMaps(listOf("frida")) || checkFridaPort()
+        return checkFridaArtifacts() || checkProcMaps(FRIDA_IMAGES) || checkFridaPort()
     }
+
+    /**
+     * Instrumentation image names, matched against the file name of a mapped
+     * library. Deliberately more specific than the framework name: a bare
+     * "frida" or "substrate" would also match an app whose own package
+     * directory, APK path, or bundled library contains that word, and a single
+     * match forces riskLevel HIGH.
+     */
+    private val FRIDA_IMAGES = listOf("frida-agent", "frida-gadget", "fridagadget", "libfrida")
+    private val XPOSED_IMAGES = listOf("libxposed", "xposedbridge", "liblspd", "libriru", "libsubstrate")
 
     /**
      * Detects an active Xposed-family hooking framework (Xposed, EdXposed,
@@ -583,9 +593,7 @@ object BiometricUtils {
     fun detectXposed(): Boolean {
         return checkXposedClasses() ||
             checkXposedStackTrace() ||
-            // Needles are library-name specific on purpose: a bare "substrate"
-            // would match any app asset path containing that word.
-            checkProcMaps(listOf("xposed", "lsposed", "liblspd", "libsubstrate"))
+            checkProcMaps(XPOSED_IMAGES)
     }
 
     /**
@@ -625,16 +633,36 @@ object BiometricUtils {
     }
 
     /**
-     * Scan the libraries mapped into this process for instrumentation frameworks
+     * Scan the libraries mapped into this process for instrumentation
+     * frameworks. Matches the mapped file's name only, never its directory
+     * path, so an app whose own package directory contains one of these words
+     * is not flagged. The app's own mappings are still scanned on purpose: a
+     * repackaged APK carries the Frida gadget in its own lib directory, which
+     * is the usual injection route on an unrooted device.
      */
     private fun checkProcMaps(needles: List<String>): Boolean {
         return try {
             java.io.File("/proc/self/maps").useLines { lines ->
-                lines.any { line -> needles.any { line.contains(it, ignoreCase = true) } }
+                lines.any { line ->
+                    val image = mappedImageName(line) ?: return@any false
+                    needles.any { image.contains(it, ignoreCase = true) }
+                }
             }
         } catch (e: Exception) {
             false
         }
+    }
+
+    /**
+     * Extracts the file name from a /proc/self/maps entry, or null for
+     * anonymous mappings and pseudo-paths such as [stack]. No field preceding
+     * the pathname (address range, perms, offset, device, inode) contains a
+     * slash, so the first one starts the path.
+     */
+    private fun mappedImageName(line: String): String? {
+        val pathStart = line.indexOf('/')
+        if (pathStart < 0) return null
+        return line.substring(pathStart).substringAfterLast('/')
     }
 
     /**

--- a/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/Utils.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativebiometrics/Utils.kt
@@ -565,27 +565,153 @@ object BiometricUtils {
     }
 
     /**
-     * Checks if the device is compromised (rooted or has security issues)
+     * Detects an active Frida instrumentation session (server artifacts on disk,
+     * frida libraries mapped into this process, or the default frida-server port
+     * listening). Best-effort heuristics: an attacker who already controls the
+     * runtime can hook these checks themselves, so treat a negative result as
+     * "nothing detected", not proof of integrity.
      */
-    fun isDeviceCompromised(context: Context): Boolean {
-        return isDeviceRooted(context) || !isKeyguardSecure(context) || !isSecureHardware(context)
+    fun detectFrida(): Boolean {
+        return checkFridaArtifacts() || checkProcMaps(listOf("frida")) || checkFridaPort()
     }
 
     /**
-     * Gets device integrity status
+     * Detects an active Xposed-family hooking framework (Xposed, EdXposed,
+     * LSPosed, Substrate) in this process via class-load probes, stack-trace
+     * inspection, and mapped libraries.
+     */
+    fun detectXposed(): Boolean {
+        return checkXposedClasses() ||
+            checkXposedStackTrace() ||
+            // Needles are library-name specific on purpose: a bare "substrate"
+            // would match any app asset path containing that word.
+            checkProcMaps(listOf("xposed", "lsposed", "liblspd", "libsubstrate"))
+    }
+
+    /**
+     * Checks whether a debugger is currently attached to this process
+     */
+    fun isDebuggerAttached(): Boolean {
+        return android.os.Debug.isDebuggerConnected() || android.os.Debug.waitingForDebugger()
+    }
+
+    /**
+     * Check for frida-server binaries in their common drop locations
+     */
+    private fun checkFridaArtifacts(): Boolean {
+        val fridaPaths = arrayOf(
+            "/data/local/tmp/frida-server",
+            "/data/local/tmp/re.frida.server",
+            "/data/local/tmp/frida-gadget.so"
+        )
+        return fridaPaths.any { java.io.File(it).exists() }
+    }
+
+    /**
+     * Probe the default frida-server port on localhost.
+     * Requires android.permission.INTERNET in the host app; without it the
+     * SecurityException is swallowed and the probe reports nothing detected.
+     * Blocks up to 300ms — callers must stay off the UI/module thread.
+     */
+    private fun checkFridaPort(): Boolean {
+        return try {
+            java.net.Socket().use { socket ->
+                socket.connect(java.net.InetSocketAddress("127.0.0.1", 27042), 300)
+                true
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Scan the libraries mapped into this process for instrumentation frameworks
+     */
+    private fun checkProcMaps(needles: List<String>): Boolean {
+        return try {
+            java.io.File("/proc/self/maps").useLines { lines ->
+                lines.any { line -> needles.any { line.contains(it, ignoreCase = true) } }
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Check whether Xposed runtime classes are loadable in this process
+     */
+    private fun checkXposedClasses(): Boolean {
+        val hookClasses = arrayOf(
+            "de.robv.android.xposed.XposedBridge",
+            "de.robv.android.xposed.XC_MethodHook"
+        )
+        return hookClasses.any { className ->
+            try {
+                ClassLoader.getSystemClassLoader().loadClass(className)
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
+
+    /**
+     * Look for hooking-framework frames in the main thread's stack. With Xposed
+     * active the main thread bottoms out in XposedBridge.main instead of
+     * ZygoteInit.main. Inspects the main thread explicitly rather than the
+     * current one, because the integrity check runs on a background thread whose
+     * stack an injected framework would never appear in.
+     */
+    private fun checkXposedStackTrace(): Boolean {
+        return try {
+            android.os.Looper.getMainLooper().thread.stackTrace.any { frame ->
+                frame.className.startsWith("de.robv.android.xposed") ||
+                    frame.className.startsWith("com.saurik.substrate")
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Checks if the device is compromised (rooted, hooked, or has security issues)
+     */
+    fun isDeviceCompromised(context: Context): Boolean {
+        return isDeviceRooted(context) ||
+            detectFrida() ||
+            detectXposed() ||
+            !isKeyguardSecure(context) ||
+            !isSecureHardware(context)
+    }
+
+    /**
+     * Gets device integrity status.
+     * Performs blocking I/O (getprop, /proc reads, a localhost port probe) —
+     * call from a background thread.
      */
     fun getDeviceIntegrityStatus(context: Context): WritableMap {
         val status = Arguments.createMap()
         val isRooted = isDeviceRooted(context)
         val isKeyguardSecure = isKeyguardSecure(context)
         val hasSecureHardware = isSecureHardware(context)
+        val fridaDetected = detectFrida()
+        val xposedDetected = detectXposed()
+        val hasRuntimeHooks = fridaDetected || xposedDetected
 
         status.putBoolean("isRooted", isRooted)
         status.putBoolean("isKeyguardSecure", isKeyguardSecure)
         status.putBoolean("hasSecureHardware", hasSecureHardware)
-        status.putBoolean("isCompromised", isRooted || !isKeyguardSecure || !hasSecureHardware)
+        status.putBoolean("hasRuntimeHooks", hasRuntimeHooks)
+        // Informational only: debuggers are routine in development, so this does
+        // not feed isCompromised/riskLevel.
+        status.putBoolean("isDebuggerAttached", isDebuggerAttached())
+        val hookDetails = Arguments.createMap()
+        hookDetails.putBoolean("fridaDetected", fridaDetected)
+        hookDetails.putBoolean("xposedDetected", xposedDetected)
+        status.putMap("runtimeHookDetails", hookDetails)
+        status.putBoolean("isCompromised", isRooted || hasRuntimeHooks || !isKeyguardSecure || !hasSecureHardware)
         status.putString("riskLevel", when {
-            isRooted -> "HIGH"
+            isRooted || hasRuntimeHooks -> "HIGH"
             !isKeyguardSecure -> "MEDIUM"
             !hasSecureHardware -> "LOW"
             else -> "NONE"

--- a/example/src/CombinedBiometricsDemo.tsx
+++ b/example/src/CombinedBiometricsDemo.tsx
@@ -257,8 +257,16 @@ export default function CombinedBiometricsDemo() {
       addTestResult('Device Integrity Check', result, !result.isCompromised);
 
       // Show alert with device status
+      const hookDetail = result.hasRuntimeHooks
+        ? `\nRuntime hooks: ${[
+            result.runtimeHookDetails?.fridaDetected && 'Frida',
+            result.runtimeHookDetails?.xposedDetected && 'Xposed',
+          ]
+            .filter(Boolean)
+            .join(', ')}`
+        : '';
       const statusMessage = result.isCompromised
-        ? `⚠️ Device Compromised!\nRisk Level: ${result.riskLevel}\n${result.isRooted ? 'Device is rooted' : ''}${result.isJailbroken ? 'Device is jailbroken' : ''}`
+        ? `⚠️ Device Compromised!\nRisk Level: ${result.riskLevel}\n${result.isRooted ? 'Device is rooted' : ''}${result.isJailbroken ? 'Device is jailbroken' : ''}${hookDetail}`
         : `✅ Device Secure\nRisk Level: ${result.riskLevel}`;
 
       Alert.alert('Device Integrity Status', statusMessage);

--- a/ios/ReactNativeBiometrics.swift
+++ b/ios/ReactNativeBiometrics.swift
@@ -1531,19 +1531,14 @@ class ReactNativeBiometrics: RCTEventEmitter {
   func getDeviceIntegrityStatus(_ resolver: @escaping RCTPromiseResolveBlock,
                                 rejecter reject: @escaping RCTPromiseRejectBlock) {
     ReactNativeBiometricDebug.debugLog("getDeviceIntegrityStatus called")
-    
-    // Call the global function from Utils.swift
-    let integrityStatus: [String: Any] = {
-      let isJailbroken = isDeviceJailbroken()
-      return [
-        "isJailbroken": isJailbroken,
-        "isCompromised": isJailbroken,
-        "riskLevel": isJailbroken ? "HIGH" : "NONE"
-      ]
-    }()
-    
-    ReactNativeBiometricDebug.debugLog("Device integrity check completed - isCompromised: \(integrityStatus["isCompromised"] as? Bool ?? false)")
-    resolver(integrityStatus)
+
+    // The global function from Utils.swift; includes a localhost port probe,
+    // so stay off the main thread.
+    DispatchQueue.global(qos: .userInitiated).async {
+      let integrityStatus = buildDeviceIntegrityStatus()
+      ReactNativeBiometricDebug.debugLog("Device integrity check completed - isCompromised: \(integrityStatus["isCompromised"] as? Bool ?? false)")
+      resolver(integrityStatus)
+    }
   }
 
   // MARK: - Biometric Change Detection

--- a/ios/Utils.swift
+++ b/ios/Utils.swift
@@ -647,8 +647,13 @@ public func detectFridaRuntime() -> Bool {
 
   for i in 0..<_dyld_image_count() {
     if let imageName = _dyld_get_image_name(i) {
-      let image = String(cString: imageName).lowercased()
-      if image.contains("frida") || image.contains("cynject") || image.contains("libcycript") {
+      // Match the image's file name, never its directory path, so an app
+      // legitimately named Frida (executable .../Frida.app/Frida) is not
+      // flagged. The app's own bundle is still scanned on purpose: a
+      // repackaged IPA carries FridaGadget.dylib inside it, which is the usual
+      // injection route on a non-jailbroken device.
+      let image = (String(cString: imageName) as NSString).lastPathComponent.lowercased()
+      if instrumentationImages.contains(where: { image.contains($0) }) {
         return true
       }
     }
@@ -656,6 +661,17 @@ public func detectFridaRuntime() -> Bool {
 
   return isLocalPortOpen(27042)
 }
+
+/**
+ * Instrumentation image names, matched against the file name of a loaded image.
+ * Deliberately more specific than the framework name: a bare "frida" or
+ * "substrate" would also match an app whose own bundle or executable contains
+ * that word, and a single match forces riskLevel HIGH.
+ */
+private let instrumentationImages = [
+  "frida-agent", "frida-gadget", "fridagadget", "libfrida",
+  "cynject", "libcycript", "libsubstrate", "mobilesubstrate"
+]
 
 /**
  * Probe a TCP port on localhost (used for the default frida-server port).

--- a/ios/Utils.swift
+++ b/ios/Utils.swift
@@ -2,6 +2,7 @@
 import Foundation
 import Security
 import LocalAuthentication
+import MachO
 import React
 import UIKit
 
@@ -630,21 +631,97 @@ private func checkJailbreakMethod3() -> Bool {
 }
 
 /**
- * Checks if the device is compromised (jailbroken or has security issues)
+ * Detects an active Frida/instrumentation session: injected libraries in
+ * DYLD_INSERT_LIBRARIES, frida images loaded into the process, or the default
+ * frida-server port listening on localhost. Best-effort heuristics: an attacker
+ * who already controls the runtime can hook these checks themselves, so treat
+ * a negative result as "nothing detected", not proof of integrity.
  */
-public func isDeviceCompromised() -> Bool {
-  return isDeviceJailbroken()
+public func detectFridaRuntime() -> Bool {
+  if let dyldInsertLibraries = getenv("DYLD_INSERT_LIBRARIES") {
+    let libraries = String(cString: dyldInsertLibraries).lowercased()
+    if libraries.contains("frida") || libraries.contains("substrate") || libraries.contains("cycript") {
+      return true
+    }
+  }
+
+  for i in 0..<_dyld_image_count() {
+    if let imageName = _dyld_get_image_name(i) {
+      let image = String(cString: imageName).lowercased()
+      if image.contains("frida") || image.contains("cynject") || image.contains("libcycript") {
+        return true
+      }
+    }
+  }
+
+  return isLocalPortOpen(27042)
 }
 
 /**
- * Gets device integrity status
+ * Probe a TCP port on localhost (used for the default frida-server port).
+ * A closed local port refuses immediately; the 300ms send timeout bounds the
+ * pathological case.
  */
-public func getDeviceIntegrityStatus() -> [String: Any] {
+private func isLocalPortOpen(_ port: UInt16) -> Bool {
+  let sock = socket(AF_INET, SOCK_STREAM, 0)
+  guard sock >= 0 else { return false }
+  defer { close(sock) }
+
+  var timeout = timeval(tv_sec: 0, tv_usec: 300_000)
+  setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+  var addr = sockaddr_in()
+  addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+  addr.sin_family = sa_family_t(AF_INET)
+  addr.sin_port = in_port_t(port).bigEndian
+  addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+  let result = withUnsafePointer(to: &addr) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+      connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+    }
+  }
+  return result == 0
+}
+
+/**
+ * Checks whether a debugger is currently attached to this process (P_TRACED)
+ */
+public func isDebuggerAttached() -> Bool {
+  var info = kinfo_proc()
+  var size = MemoryLayout<kinfo_proc>.stride
+  var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+  guard sysctl(&mib, u_int(mib.count), &info, &size, nil, 0) == 0 else {
+    return false
+  }
+  return (info.kp_proc.p_flag & P_TRACED) != 0
+}
+
+/**
+ * Checks if the device is compromised (jailbroken or actively hooked)
+ */
+public func isDeviceCompromised() -> Bool {
+  return isDeviceJailbroken() || detectFridaRuntime()
+}
+
+/**
+ * Gets device integrity status.
+ * Named distinctly from the module's `getDeviceIntegrityStatus(_:rejecter:)` so
+ * the call site inside the class resolves here instead of being shadowed by the
+ * member of the same name.
+ */
+public func buildDeviceIntegrityStatus() -> [String: Any] {
   let isJailbroken = isDeviceJailbroken()
+  let fridaDetected = detectFridaRuntime()
 
   return [
     "isJailbroken": isJailbroken,
-    "isCompromised": isJailbroken,
-    "riskLevel": isJailbroken ? "HIGH" : "NONE"
+    "hasRuntimeHooks": fridaDetected,
+    // Informational only: debuggers are routine in development, so this does
+    // not feed isCompromised/riskLevel.
+    "isDebuggerAttached": isDebuggerAttached(),
+    "runtimeHookDetails": ["fridaDetected": fridaDetected],
+    "isCompromised": isJailbroken || fridaDetected,
+    "riskLevel": (isJailbroken || fridaDetected) ? "HIGH" : "NONE"
   ]
 }

--- a/src/NativeReactNativeBiometrics.ts
+++ b/src/NativeReactNativeBiometrics.ts
@@ -211,6 +211,12 @@ export interface Spec extends TurboModule {
     isJailbroken?: boolean;
     isKeyguardSecure?: boolean;
     hasSecureHardware?: boolean;
+    hasRuntimeHooks?: boolean;
+    isDebuggerAttached?: boolean;
+    runtimeHookDetails?: {
+      fridaDetected: boolean;
+      xposedDetected?: boolean;
+    };
     isCompromised: boolean;
     riskLevel: 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'UNKNOWN';
     error?: string;

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -71,6 +71,19 @@ const MOCK_RESPONSES = {
     isCompromised: false,
     riskLevel: 'low',
   },
+  deviceIntegrityHooked: {
+    isRooted: false,
+    isKeyguardSecure: true,
+    hasSecureHardware: true,
+    hasRuntimeHooks: true,
+    isDebuggerAttached: false,
+    runtimeHookDetails: {
+      fridaDetected: true,
+      xposedDetected: false,
+    },
+    isCompromised: true,
+    riskLevel: 'HIGH',
+  },
 };
 
 // Default mock implementation
@@ -844,6 +857,45 @@ describe('ReactNativeBiometrics', () => {
       expect(result.isJailbroken).toBeUndefined();
       expect(result.isKeyguardSecure).toBe(true);
       expect(result.hasSecureHardware).toBe(true);
+    });
+
+    it('should surface runtime hook detection fields', async () => {
+      jest.resetModules();
+      jest.doMock('../NativeReactNativeBiometrics', () =>
+        createMockNative({
+          getDeviceIntegrityStatus: jest.fn(() =>
+            Promise.resolve(MOCK_RESPONSES.deviceIntegrityHooked)
+          ),
+        })
+      );
+      const BiometricsModule = await import('../index');
+      const result = await BiometricsModule.getDeviceIntegrityStatus();
+      expect(result).toEqual(MOCK_RESPONSES.deviceIntegrityHooked);
+      expect(result.hasRuntimeHooks).toBe(true);
+      expect(result.runtimeHookDetails).toEqual({
+        fridaDetected: true,
+        xposedDetected: false,
+      });
+      expect(result.isCompromised).toBe(true);
+      expect(result.riskLevel).toBe('HIGH');
+    });
+
+    it('should keep debugger attachment separate from compromise status', async () => {
+      jest.resetModules();
+      jest.doMock('../NativeReactNativeBiometrics', () =>
+        createMockNative({
+          getDeviceIntegrityStatus: jest.fn(() =>
+            Promise.resolve({
+              ...MOCK_RESPONSES.deviceIntegrityAndroid,
+              isDebuggerAttached: true,
+            })
+          ),
+        })
+      );
+      const BiometricsModule = await import('../index');
+      const result = await BiometricsModule.getDeviceIntegrityStatus();
+      expect(result.isDebuggerAttached).toBe(true);
+      expect(result.isCompromised).toBe(false);
     });
 
     it('should handle different risk levels', async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -795,6 +795,7 @@ export function getDeviceIntegrityStatus(): Promise<DeviceIntegrityResult> {
         {
           isCompromised: result.isCompromised,
           riskLevel: result.riskLevel,
+          hasRuntimeHooks: result.hasRuntimeHooks,
         }
       );
       return result;
@@ -1100,6 +1101,12 @@ export type DeviceIntegrityResult = {
   isJailbroken?: boolean;
   isKeyguardSecure?: boolean;
   hasSecureHardware?: boolean;
+  hasRuntimeHooks?: boolean;
+  isDebuggerAttached?: boolean;
+  runtimeHookDetails?: {
+    fridaDetected: boolean;
+    xposedDetected?: boolean;
+  };
   isCompromised: boolean;
   riskLevel: 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'UNKNOWN';
   error?: string;


### PR DESCRIPTION
Closes #71

## Problem

`getDeviceIntegrityStatus()` performed **static** checks only — root/jailbreak binaries, dangerous props, root management apps. Magisk Hide and Shamiko hide those indicators from apps while Frida or Xposed actively hooks the process, so a device could report `isRooted: false` with instrumentation attached. For banking and payment apps that distinction matters.

The issue scoped this to Android on the premise that "iOS already covers Frida via the `DYLD_INSERT_LIBRARIES` env check". That turned out to be only half true: the `/usr/sbin/frida-server` **path** check existed, but the `DYLD_INSERT_LIBRARIES` scan matched only `MobileSubstrate` and `cycript` — never `frida`. iOS had the same static-only gap, so this covers **both platforms**.

## API

Extends the existing result rather than adding a new native method, so no arch-module or bridge changes are needed and the payload stays backward compatible through optional fields:

```ts
type DeviceIntegrityResult = {
  // ...existing fields
  hasRuntimeHooks?: boolean;
  isDebuggerAttached?: boolean;
  runtimeHookDetails?: {
    fridaDetected: boolean;
    xposedDetected?: boolean; // Android only
  };
};
```

- **Android** — Frida (server artifacts, `/proc/self/maps`, port 27042) and Xposed/LSPosed (system classloader probe, main-thread stack trace, mapped libraries).
- **iOS** — Frida via `DYLD_INSERT_LIBRARIES`, the dyld loaded-image list, and the same port probe.

Detected hooks set `isCompromised: true` and `riskLevel: 'HIGH'`. `isDebuggerAttached` is informational and deliberately excluded from both, otherwise every development build would report itself compromised.

## Incidental fixes

- **The iOS global `getDeviceIntegrityStatus()` in `Utils.swift` was dead code.** The module method carried a comment saying "Call the global function from Utils.swift" and then duplicated the logic inline instead — because inside the class, the `@objc` member of the same name shadows the module-scope global, so the call never resolved. Renamed to `buildDeviceIntegrityStatus()`; the duplication is gone and there is now a single implementation.
- **Both platforms ran the checks on the calling thread.** Harmless before, but the localhost port probe would throw `NetworkOnMainThreadException` on Android. Android now runs on a background thread, iOS on a global queue.

## Caveats (documented in the README)

Detection is best-effort: an attacker already controlling the runtime can hook the detection itself, rename binaries, or move frida-server off its default port. A negative result is not proof of integrity, and the README points at Play Integrity / App Attest for server-verifiable signals.

Two environment notes are also documented: the Android port probe needs the host app to hold `INTERNET` (the library deliberately does not declare it for consumers) and degrades silently without it; and the iOS **Simulator** shares localhost with the macOS host, so a `frida-server` running on your Mac registers as a hook inside the simulator — verify on a physical device.

## Verification

- Android `compileDebugKotlin` passes on **both** architectures — verified new-arch genuinely compiled by confirming `ReactNativeBiometricsSpec.class` (which exists only in the `newarch` source set) landed in the output. Codegen ran and accepted the updated spec.
- iOS pod target builds (`BUILD SUCCEEDED`).
- `yarn typecheck`, `yarn lint` (0 errors), and all 104 Jest tests pass, including 2 new ones covering the new fields and the debugger/compromise separation.

Native detection behaviour still needs manual confirmation on a rooted/hooked physical device — the JS tests mock the native module by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device integrity results now report runtime hooks, including Frida and Xposed detection details.
  * Debugger attachment status is available separately from compromise status.
  * Integrity alerts display detected runtime instrumentation when present.
  * Integrity checks run asynchronously to help maintain app responsiveness.

* **Documentation**
  * Added platform-specific detection notes, limitations, and troubleshooting guidance for Android release crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->